### PR TITLE
NullPointerException in ckeditor widget after ajax update

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/widget.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/widget.js
@@ -386,6 +386,10 @@ PrimeFacesExt.widget.CKEditor = PrimeFaces.widget.BaseWidget.extend({
 	 * Checks if the editor is in dirty state.
 	 */
 	isDirty : function() {
+		if (!this.instance) {
+			return false;
+		}
+
 		return this.dirtyState || this.instance.checkDirty();
 	},
 


### PR DESCRIPTION
The form content mask contains a ckeditor. The mask will be replaces by a new one containing a new instance of ckeditor (forward navigation in our application). If we navigate back and typing changes in first ckeditor instance the console shows NPE.

![ckeditor_npe](https://f.cloud.github.com/assets/3490002/130986/8da32b38-7044-11e2-970b-2b8f8fcee02c.png)
