### PR TITLE
Add line&column support to CodeMirror completion event

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirror.java
+++ b/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirror.java
@@ -449,7 +449,7 @@ public class CodeMirror extends HtmlInputTextarea implements ClientBehaviorHolde
 
 			suggestions = (List<String>) completeMethod.invoke(
 					facesContext.getELContext(),
-					new Object[] { completeEvent.getToken(), completeEvent.getContext()});
+                    new Object[] { completeEvent.getToken(), completeEvent.getContext(), completeEvent.getLine(), completeEvent.getColumn()});
 
 			if (suggestions == null) {
 				suggestions = new ArrayList<String>();

--- a/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirror.java
+++ b/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirror.java
@@ -445,11 +445,9 @@ public class CodeMirror extends HtmlInputTextarea implements ClientBehaviorHolde
 		final MethodExpression completeMethod = getCompleteMethod();
 
 		if (completeMethod != null && event instanceof CompleteEvent) {
-			final CompleteEvent completeEvent = (CompleteEvent) event;
-
 			suggestions = (List<String>) completeMethod.invoke(
 					facesContext.getELContext(),
-                    new Object[] { completeEvent.getToken(), completeEvent.getContext(), completeEvent.getLine(), completeEvent.getColumn()});
+                    new Object[] { event });
 
 			if (suggestions == null) {
 				suggestions = new ArrayList<String>();

--- a/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirrorHandler.java
+++ b/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirrorHandler.java
@@ -44,7 +44,7 @@ public class CodeMirrorHandler extends ComponentHandler {
 	protected MetaRuleset createMetaRuleset(final Class type) {
 		MetaRuleset metaRuleset = super.createMetaRuleset(type);
 
-		metaRuleset.addRule(new MethodRule("completeMethod", List.class, new Class[] { String.class, String.class }));
+        metaRuleset.addRule(new MethodRule("completeMethod", List.class, new Class[] { String.class, String.class, Integer.class, Integer.class }));
 
 		return metaRuleset;
 	}

--- a/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirrorHandler.java
+++ b/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirrorHandler.java
@@ -18,13 +18,13 @@
 
 package org.primefaces.extensions.component.codemirror;
 
-import java.util.List;
+import org.primefaces.extensions.event.CompleteEvent;
+import org.primefaces.facelets.MethodRule;
 
 import javax.faces.view.facelets.ComponentConfig;
 import javax.faces.view.facelets.ComponentHandler;
 import javax.faces.view.facelets.MetaRuleset;
-
-import org.primefaces.facelets.MethodRule;
+import java.util.List;
 
 /**
  * {@link ComponentHandler} for the {@link CodeMirror} component.
@@ -44,7 +44,7 @@ public class CodeMirrorHandler extends ComponentHandler {
 	protected MetaRuleset createMetaRuleset(final Class type) {
 		MetaRuleset metaRuleset = super.createMetaRuleset(type);
 
-        metaRuleset.addRule(new MethodRule("completeMethod", List.class, new Class[] { String.class, String.class, Integer.class, Integer.class }));
+        metaRuleset.addRule(new MethodRule("completeMethod", List.class, new Class[] { CompleteEvent.class }));
 
 		return metaRuleset;
 	}

--- a/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirrorRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirrorRenderer.java
@@ -63,9 +63,10 @@ public class CodeMirrorRenderer extends InputRenderer {
 
         // complete event
         final String token = params.get(clientId + "_token");
+        final Cursor cursor = new Cursor(params.get(clientId + "_line"), params.get(clientId + "_column"));
         if (token != null) {
-        	final String context = params.get(clientId + "_context");
-        	final CompleteEvent autoCompleteEvent = new CompleteEvent(codeMirror, token, context);
+            final String context = params.get(clientId + "_context");
+            final CompleteEvent autoCompleteEvent = new CompleteEvent(codeMirror, token, context, cursor.line, cursor.column);
             autoCompleteEvent.setPhaseId(PhaseId.APPLY_REQUEST_VALUES);
 
             codeMirror.queueEvent(autoCompleteEvent);
@@ -198,5 +199,24 @@ public class CodeMirrorRenderer extends InputRenderer {
     	}
 
     	writer.endElement("ul");
+    }
+
+    private final class Cursor {
+
+        int line;
+        int column;
+
+        public Cursor(String line, String column) {
+            try {
+                this.line = Integer.parseInt(line);
+            } catch (NumberFormatException nfe) {
+                this.line = -1;
+            }
+            try {
+                this.column = Integer.parseInt(column);
+            } catch (NumberFormatException nfe) {
+                this.column = -1;
+            }
+        }
     }
 }

--- a/src/main/java/org/primefaces/extensions/event/CompleteEvent.java
+++ b/src/main/java/org/primefaces/extensions/event/CompleteEvent.java
@@ -9,11 +9,15 @@ public class CompleteEvent extends FacesEvent {
 
     private String token;
     private String context;
+    private int line;
+    private int column;
 
-    public CompleteEvent(final UIComponent component, final String token, final String context) {
+    public CompleteEvent(final UIComponent component, final String token, final String context, final int line, final int column) {
         super(component);
         this.token = token;
         this.context = context;
+        this.line = line;
+        this.column = column;
     }
 
     @Override
@@ -32,5 +36,13 @@ public class CompleteEvent extends FacesEvent {
 
     public String getContext() {
         return context;
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public int getColumn() {
+        return column;
     }
 }


### PR DESCRIPTION
Together with a pull request on the resources-codemirror module these changes add line&column support to the CodeMirror completion event.

I've added this because I'm working on a Java compiler based autocompletion module (that needs the cursor location) that can be used in combination with the CodeMirror module to create a sort of simple Java IDE functionality that can be integrated into JSF webapps.
