### PR TITLE
Timeline events are offset (1)

### DIFF
--- a/src/main/java/org/primefaces/extensions/util/DateUtils.java
+++ b/src/main/java/org/primefaces/extensions/util/DateUtils.java
@@ -47,7 +47,7 @@ public class DateUtils {
 	public static Date toUtcDate(Calendar calendar, TimeZone localTimeZone, Date localDate) {
 		int offsetFromUTC = localTimeZone.getOffset(localDate.getTime()) * (-1);
 		calendar.setTime(localDate);
-		calendar.add(Calendar.MILLISECOND, offsetFromUTC);
+		//calendar.add(Calendar.MILLISECOND, offsetFromUTC);
 
 		return calendar.getTime();
 	}
@@ -56,7 +56,7 @@ public class DateUtils {
 	public static long toLocalDate(Calendar calendar, TimeZone localTimeZone, Date utcDate) {
 		int offsetFromUTC = localTimeZone.getOffset(utcDate.getTime());
 		calendar.setTime(utcDate);
-		calendar.add(Calendar.MILLISECOND, offsetFromUTC);
+		//calendar.add(Calendar.MILLISECOND, offsetFromUTC);
 
 		return calendar.getTimeInMillis();
 	}


### PR DESCRIPTION
Now respects daylight saving correctly - but the timeline ALWAYS displays using local (browser) time zone, regardless of the "timeZone" parameter in the JSF tag. It could be resolved by adjusting the UTC time, but the problem is I don't know how much to adjust the time by. I can see three possible solutions: (1) Identify what timeZone the browser is using; (2) make the timeline always display based on UTC time, rather than local time; or (3) make the javascript take account of the specified timezone when displaying (but from my limited research I don't see Javascript Dates being bale to do this). Can anyone contribute to solving this please?
