### PR TITLE
Corrects "Timeline events are offset" issue

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/timeline/DefaultTimelineUpdater.java
+++ b/src/main/java/org/primefaces/extensions/component/timeline/DefaultTimelineUpdater.java
@@ -21,7 +21,6 @@ package org.primefaces.extensions.component.timeline;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.logging.Level;
@@ -91,10 +90,12 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
 		crudOperationDatas.add(new CrudOperationData(CrudOperation.CLEAR));
 	}
 
+        @Override
 	public PhaseId getPhaseId() {
 		return PhaseId.RENDER_RESPONSE;
 	}
 
+        @Override
 	public void beforePhase(PhaseEvent event) {
 		if (crudOperationDatas == null) {
 			return;
@@ -109,8 +110,8 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
 		TimelineRenderer timelineRenderer =
 		    (TimelineRenderer) fc.getRenderKit().getRenderer(Timeline.COMPONENT_FAMILY, Timeline.DEFAULT_RENDERER);
 
-		TimeZone timeZone = ComponentUtils.resolveTimeZone(timeline.getTimeZone());
-		Calendar calendar = Calendar.getInstance(timeZone);
+		TimeZone targetTZ = ComponentUtils.resolveTimeZone(timeline.getTimeZone());
+		TimeZone browserTZ = ComponentUtils.resolveTimeZone(timeline.getBrowserTZ(), targetTZ);
 
 		try {
 			for (CrudOperationData crudOperationData : crudOperationDatas) {
@@ -120,7 +121,7 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
 					sb.append(";");
 					sb.append(widgetVar);
 					sb.append(".addEvent(");
-					sb.append(timelineRenderer.encodeEvent(fc, fsw, fswHtml, timeline, calendar, timeZone,
+					sb.append(timelineRenderer.encodeEvent(fc, fsw, fswHtml, timeline, browserTZ, targetTZ,
 					                                       crudOperationData.getEvent()));
 					sb.append(")");
 					break;
@@ -132,7 +133,7 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
 					sb.append(".changeEvent(");
 					sb.append(crudOperationData.getIndex());
 					sb.append(",");
-					sb.append(timelineRenderer.encodeEvent(fc, fsw, fswHtml, timeline, calendar, timeZone,
+					sb.append(timelineRenderer.encodeEvent(fc, fsw, fswHtml, timeline, browserTZ, targetTZ,
 					                                       crudOperationData.getEvent()));
 					sb.append(")");
 					break;
@@ -171,6 +172,7 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
 		}
 	}
 
+        @Override
 	public void afterPhase(PhaseEvent event) {
 		// NOOP.
 	}

--- a/src/main/java/org/primefaces/extensions/component/timeline/Timeline.java
+++ b/src/main/java/org/primefaces/extensions/component/timeline/Timeline.java
@@ -19,7 +19,6 @@ package org.primefaces.extensions.component.timeline;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -87,6 +86,7 @@ public class Timeline extends UIComponentBase implements Widget, ClientBehaviorH
 		var,
 		locale,
 		timeZone,
+		browserTZ,
 		style,
 		styleClass,
 		height,
@@ -181,6 +181,14 @@ public class Timeline extends UIComponentBase implements Widget, ClientBehaviorH
 
 	public void setTimeZone(Object timeZone) {
 		setAttribute(PropertyKeys.timeZone, timeZone);
+	}
+
+	public Object getBrowserTZ() {
+		return getStateHelper().eval(PropertyKeys.browserTZ, null);
+	}
+
+	public void setBrowserTZ(Object timeZone) {
+		setAttribute(PropertyKeys.browserTZ, timeZone);
 	}
 
 	public String getStyle() {
@@ -448,12 +456,12 @@ public class Timeline extends UIComponentBase implements Widget, ClientBehaviorH
 
 			if ("add".equals(eventName)) {
 				// preset start / end date and the group
-				Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-				TimeZone timeZone = ComponentUtils.resolveTimeZone(getTimeZone());
+				TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
+				TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTZ(), targetTZ);
 				TimelineAddEvent te =
 				    new TimelineAddEvent(this, behaviorEvent.getBehavior(),
-				                         DateUtils.toUtcDate(calendar, timeZone, params.get(clientId + "_startDate")),
-				                         DateUtils.toUtcDate(calendar, timeZone, params.get(clientId + "_endDate")),
+				                         DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDate")),
+				                         DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDate")),
 				                         params.get(clientId + "_group"));
 				te.setPhaseId(behaviorEvent.getPhaseId());
 				super.queueEvent(te);
@@ -470,10 +478,10 @@ public class Timeline extends UIComponentBase implements Widget, ClientBehaviorH
 					clonedEvent.setStyleClass(timelineEvent.getStyleClass());
 
 					// update start / end date and the group
-					Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-					TimeZone timeZone = ComponentUtils.resolveTimeZone(getTimeZone());
-					clonedEvent.setStartDate(DateUtils.toUtcDate(calendar, timeZone, params.get(clientId + "_startDate")));
-					clonedEvent.setEndDate(DateUtils.toUtcDate(calendar, timeZone, params.get(clientId + "_endDate")));
+					TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
+					TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTZ(), targetTZ);
+					clonedEvent.setStartDate(DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDate")));
+					clonedEvent.setEndDate(DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDate")));
 					clonedEvent.setGroup(params.get(clientId + "_group"));
 				}
 
@@ -510,24 +518,24 @@ public class Timeline extends UIComponentBase implements Widget, ClientBehaviorH
 				return;
 			} else if ("rangechange".equals(eventName)) {
 				// get start / end date
-				Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-				TimeZone timeZone = ComponentUtils.resolveTimeZone(getTimeZone());
+				TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
+				TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTZ(), targetTZ);
 				TimelineRangeEvent te =
 				    new TimelineRangeEvent(this, behaviorEvent.getBehavior(),
-				                           DateUtils.toUtcDate(calendar, timeZone, params.get(clientId + "_startDate")),
-				                           DateUtils.toUtcDate(calendar, timeZone, params.get(clientId + "_endDate")));
+				                           DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDate")),
+				                           DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDate")));
 				te.setPhaseId(behaviorEvent.getPhaseId());
 				super.queueEvent(te);
 
 				return;
 			} else if ("rangechanged".equals(eventName)) {
 				// get start / end date
-				Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-				TimeZone timeZone = ComponentUtils.resolveTimeZone(getTimeZone());
+				TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
+				TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTZ(), targetTZ);
 				TimelineRangeEvent te =
 				    new TimelineRangeEvent(this, behaviorEvent.getBehavior(),
-				                           DateUtils.toUtcDate(calendar, timeZone, params.get(clientId + "_startDate")),
-				                           DateUtils.toUtcDate(calendar, timeZone, params.get(clientId + "_endDate")));
+				                           DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDate")),
+				                           DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDate")));
 				te.setPhaseId(behaviorEvent.getPhaseId());
 				super.queueEvent(te);
 
@@ -543,6 +551,7 @@ public class Timeline extends UIComponentBase implements Widget, ClientBehaviorH
 		           .equals(context.getExternalContext().getRequestParameterMap().get(Constants.PARTIAL_SOURCE_PARAM));
 	}
 
+        @Override
 	public String resolveWidgetVar() {
 		final FacesContext context = FacesContext.getCurrentInstance();
 		final String userWidgetVar = (String) getAttributes().get(PropertyKeys.widgetVar.toString());

--- a/src/main/java/org/primefaces/extensions/component/timeline/TimelineRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/timeline/TimelineRenderer.java
@@ -19,7 +19,6 @@
 package org.primefaces.extensions.component.timeline;
 
 import java.io.IOException;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -83,8 +82,8 @@ public class TimelineRenderer extends CoreRenderer {
 
 		ResponseWriter writer = context.getResponseWriter();
 		String clientId = timeline.getClientId(context);
-		TimeZone timeZone = ComponentUtils.resolveTimeZone(timeline.getTimeZone());
-		Calendar calendar = Calendar.getInstance(timeZone);
+		TimeZone targetTZ = ComponentUtils.resolveTimeZone(timeline.getTimeZone());
+		TimeZone browserTZ = ComponentUtils.resolveTimeZone(timeline.getBrowserTZ(), targetTZ);
 		FastStringWriter fsw = new FastStringWriter();
 		FastStringWriter fswHtml = new FastStringWriter();
 
@@ -98,7 +97,7 @@ public class TimelineRenderer extends CoreRenderer {
 		List<TimelineEvent> events = model.getEvents();
 		int size = events != null ? events.size() : 0;
 		for (int i = 0; i < size; i++) {
-			writer.write(encodeEvent(context, fsw, fswHtml, timeline, calendar, timeZone, events.get(i)));
+			writer.write(encodeEvent(context, fsw, fswHtml, timeline, browserTZ, targetTZ, events.get(i)));
 			if (i + 1 < size) {
 				writer.write(",");
 			}
@@ -119,19 +118,19 @@ public class TimelineRenderer extends CoreRenderer {
 		writer.write(",moveable:" + timeline.isMoveable());
 
 		if (timeline.getStart() != null) {
-			writer.write(",start:" + encodeDate(calendar, timeZone, timeline.getStart()));
+			writer.write(",start:" + encodeDate(browserTZ, targetTZ, timeline.getStart()));
 		}
 
 		if (timeline.getEnd() != null) {
-			writer.write(",end:" + encodeDate(calendar, timeZone, timeline.getEnd()));
+			writer.write(",end:" + encodeDate(browserTZ, targetTZ, timeline.getEnd()));
 		}
 
 		if (timeline.getMin() != null) {
-			writer.write(",min:" + encodeDate(calendar, timeZone, timeline.getMin()));
+			writer.write(",min:" + encodeDate(browserTZ, targetTZ, timeline.getMin()));
 		}
 
 		if (timeline.getMax() != null) {
-			writer.write(",max:" + encodeDate(calendar, timeZone, timeline.getMax()));
+			writer.write(",max:" + encodeDate(browserTZ, targetTZ, timeline.getMax()));
 		}
 
 		writer.write(",zoomMin:" + timeline.getZoomMin());
@@ -165,13 +164,13 @@ public class TimelineRenderer extends CoreRenderer {
 	}
 
 	public String encodeEvent(FacesContext context, FastStringWriter fsw, FastStringWriter fswHtml, Timeline timeline,
-	                          Calendar calendar, TimeZone timeZone, TimelineEvent event) throws IOException {
+	                          TimeZone browserTZ, TimeZone targetTZ, TimelineEvent event) throws IOException {
 		ResponseWriter writer = context.getResponseWriter();
 
-		fsw.write("{\"start\":" + encodeDate(calendar, timeZone, event.getStartDate()));
+		fsw.write("{\"start\":" + encodeDate(browserTZ, targetTZ, event.getStartDate()));
 
 		if (event.getEndDate() != null) {
-			fsw.write(",\"end\":" + encodeDate(calendar, timeZone, event.getEndDate()));
+			fsw.write(",\"end\":" + encodeDate(browserTZ, targetTZ, event.getEndDate()));
 		} else {
 			fsw.write(",\"end\":null");
 		}
@@ -224,8 +223,8 @@ public class TimelineRenderer extends CoreRenderer {
 	}
 
 	// convert from UTC to locale date
-	private String encodeDate(Calendar calendar, TimeZone localTimeZone, Date utcDate) {
-		return "new Date(" + DateUtils.toLocalDate(calendar, localTimeZone, utcDate) + ")";
+	private String encodeDate(TimeZone browserTZ, TimeZone targetTZ, Date utcDate) {
+		return "new Date(" + DateUtils.toLocalDate(browserTZ, targetTZ, utcDate) + ")";
 	}
 
 	@Override

--- a/src/main/java/org/primefaces/extensions/converter/TimelineEventsConverter.java
+++ b/src/main/java/org/primefaces/extensions/converter/TimelineEventsConverter.java
@@ -17,7 +17,6 @@
 package org.primefaces.extensions.converter;
 
 import java.util.Date;
-import java.util.TimeZone;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
@@ -42,13 +41,11 @@ public class TimelineEventsConverter extends JsonConverter {
 
 	private static final String TYPE_FOR_EVENTS = "java.util.List<org.primefaces.extensions.model.timeline.TimelineEvent>";
 
-	private Object timeZone;
-
 	@Override
 	public Object getAsObject(FacesContext context, UIComponent component, String value) {
 		// register a time zone aware date adapter
 		GsonBuilder gsonBilder = new GsonBuilder();
-		gsonBilder.registerTypeAdapter(Date.class, new DateTypeAdapter(timeZone == null ? TimeZone.getDefault() : timeZone));
+		gsonBilder.registerTypeAdapter(Date.class, new DateTypeAdapter());
 		gsonBilder.serializeNulls();
 
 		return gsonBilder.create().fromJson(value, getObjectType(TYPE_FOR_EVENTS, false));
@@ -58,17 +55,9 @@ public class TimelineEventsConverter extends JsonConverter {
 	public String getAsString(FacesContext context, UIComponent component, Object value) {
 		// register a time zone aware date adapter
 		GsonBuilder gsonBilder = new GsonBuilder();
-		gsonBilder.registerTypeAdapter(Date.class, new DateTypeAdapter(timeZone == null ? TimeZone.getDefault() : timeZone));
+		gsonBilder.registerTypeAdapter(Date.class, new DateTypeAdapter());
 		gsonBilder.serializeNulls();
 
 		return gsonBilder.create().toJson(value, getObjectType(TYPE_FOR_EVENTS, false));
-	}
-
-	public Object getTimeZone() {
-		return timeZone;
-	}
-
-	public void setTimeZone(Object timeZone) {
-		this.timeZone = timeZone;
 	}
 }

--- a/src/main/java/org/primefaces/extensions/util/ComponentUtils.java
+++ b/src/main/java/org/primefaces/extensions/util/ComponentUtils.java
@@ -497,12 +497,23 @@ public class ComponentUtils extends org.primefaces.util.ComponentUtils {
 	 * @return resolved TimeZone
 	 */
 	public static TimeZone resolveTimeZone(Object timeZone) {
+		return resolveTimeZone(timeZone, null);
+	}
+	/**
+	 * Gets a {@link TimeZone defaultTZ} instance by the value of the component attribute "timeZone" which can be String or {@link TimeZone}
+	 * or null.
+	 *
+	 * @param  timeZone given time zone
+	 * @param  default timeZone if the timeZone object doesn't resolve
+	 * @return resolved TimeZone
+	 */
+	public static TimeZone resolveTimeZone(Object timeZone, TimeZone defaultTZ) {
 		if (timeZone instanceof String) {
 			return TimeZone.getTimeZone((String) timeZone);
 		} else if (timeZone instanceof TimeZone) {
 			return (TimeZone) timeZone;
 		} else {
-			return TimeZone.getDefault();
+			return ((defaultTZ == null) ? TimeZone.getDefault() : defaultTZ);
 		}
 	}
 }

--- a/src/main/java/org/primefaces/extensions/util/DateUtils.java
+++ b/src/main/java/org/primefaces/extensions/util/DateUtils.java
@@ -16,7 +16,6 @@
 
 package org.primefaces.extensions.util;
 
-import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -30,34 +29,34 @@ import java.util.TimeZone;
 public class DateUtils {
 
 	// convert from local date to UTC
-	public static Date toUtcDate(Calendar calendar, TimeZone localTimeZone, String localTime) {
-		if (localTime == null) {
+	public static Date toUtcDate(TimeZone browserTZ, TimeZone targetTZ, String localDate) {
+		if (localDate == null) {
 			return null;
 		}
-
-		return toUtcDate(calendar, localTimeZone, Long.valueOf(localTime));
+		return toUtcDate(browserTZ, targetTZ, Long.valueOf(localDate));
 	}
 
 	// convert from local date to UTC
-	public static Date toUtcDate(Calendar calendar, TimeZone localTimeZone, long localTime) {
-		return toUtcDate(calendar, localTimeZone, new Date(localTime));
+	public static Date toUtcDate(TimeZone browserTZ, TimeZone targetTZ, long localDate) {
+		return toUtcDate(browserTZ, targetTZ, new Date(localDate));
 	}
 
 	// convert from local date to UTC
-	public static Date toUtcDate(Calendar calendar, TimeZone localTimeZone, Date localDate) {
-		int offsetFromUTC = localTimeZone.getOffset(localDate.getTime()) * (-1);
-		calendar.setTime(localDate);
-		//calendar.add(Calendar.MILLISECOND, offsetFromUTC);
-
-		return calendar.getTime();
+	public static Date toUtcDate(TimeZone browserTZ, TimeZone targetTZ, Date localDate) {
+                if ( localDate == null ) {
+                    return null;
+                }
+                long local = localDate.getTime();
+		int targetOffsetFromUTC = targetTZ.getOffset(local);
+		int browserOffsetFromUTC = browserTZ.getOffset(local);
+                return new Date( local - targetOffsetFromUTC + browserOffsetFromUTC );
 	}
 
 	// convert from UTC to local date
-	public static long toLocalDate(Calendar calendar, TimeZone localTimeZone, Date utcDate) {
-		int offsetFromUTC = localTimeZone.getOffset(utcDate.getTime());
-		calendar.setTime(utcDate);
-		//calendar.add(Calendar.MILLISECOND, offsetFromUTC);
-
-		return calendar.getTimeInMillis();
+	public static long toLocalDate(TimeZone browserTZ, TimeZone targetTZ, Date utcDate) {
+                long utc = utcDate.getTime();
+		int targetOffsetFromUTC = targetTZ.getOffset(utc);
+		int browserOffsetFromUTC = browserTZ.getOffset(utc);
+                return utc + targetOffsetFromUTC - browserOffsetFromUTC;
 	}
 }

--- a/src/main/java/org/primefaces/extensions/util/DateUtils.java
+++ b/src/main/java/org/primefaces/extensions/util/DateUtils.java
@@ -47,7 +47,7 @@ public class DateUtils {
 	public static Date toUtcDate(Calendar calendar, TimeZone localTimeZone, Date localDate) {
 		int offsetFromUTC = localTimeZone.getOffset(localDate.getTime()) * (-1);
 		calendar.setTime(localDate);
-		calendar.add(Calendar.MILLISECOND, offsetFromUTC);
+		//calendar.add(Calendar.MILLISECOND, offsetFromUTC);
 
 		return calendar.getTime();
 	}
@@ -56,7 +56,7 @@ public class DateUtils {
 	public static long toLocalDate(Calendar calendar, TimeZone localTimeZone, Date utcDate) {
 		int offsetFromUTC = localTimeZone.getOffset(utcDate.getTime());
 		calendar.setTime(utcDate);
-		calendar.add(Calendar.MILLISECOND, offsetFromUTC);
+		//calendar.add(Calendar.MILLISECOND, offsetFromUTC);
 
 		return calendar.getTimeInMillis();
 	}

--- a/src/main/java/org/primefaces/extensions/util/json/DateTypeAdapter.java
+++ b/src/main/java/org/primefaces/extensions/util/json/DateTypeAdapter.java
@@ -19,12 +19,7 @@
 package org.primefaces.extensions.util.json;
 
 import java.lang.reflect.Type;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.TimeZone;
-
-import org.primefaces.extensions.util.ComponentUtils;
-import org.primefaces.extensions.util.DateUtils;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -43,42 +38,17 @@ import com.google.gson.JsonSerializer;
  */
 public class DateTypeAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
 
-	private Object timeZone;
-
 	public DateTypeAdapter() {
 	}
 
-	public DateTypeAdapter(Object timeZone) {
-		this.timeZone = timeZone;
-	}
-
+        @Override
 	public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
-		if (timeZone == null) {
-			return new JsonPrimitive(src.getTime());
-		} else {
-			TimeZone tz = ComponentUtils.resolveTimeZone(timeZone);
-			Calendar calendar = Calendar.getInstance(tz);
-
-			return new JsonPrimitive(DateUtils.toLocalDate(calendar, tz, src));
-		}
+        	return new JsonPrimitive(src.getTime());
 	}
 
+        @Override
 	public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-		if (timeZone == null) {
-			return new Date(json.getAsJsonPrimitive().getAsLong());
-		} else {
-			Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-			TimeZone tz = ComponentUtils.resolveTimeZone(timeZone);
-
-			return DateUtils.toUtcDate(calendar, tz, json.getAsJsonPrimitive().getAsLong());
-		}
+		return new Date(json.getAsJsonPrimitive().getAsLong());
 	}
 
-	public Object getTimeZone() {
-		return timeZone;
-	}
-
-	public void setTimeZone(Object timeZone) {
-		this.timeZone = timeZone;
-	}
 }

--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <facelet-taglib version="2.0"
                 xmlns="http://java.sun.com/xml/ns/javaee"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -86,14 +86,14 @@
         <converter>
             <converter-id>org.primefaces.extensions.converter.TimelineEventsConverter</converter-id>
         </converter>
-        <attribute>
+<!--        <attribute>
             <description>
                 <![CDATA[Time zone for UTC / Local date conversion. It can be a TimeZone object as well as a String with time zone Id.]]>
             </description>
             <name>timeZone</name>
             <required>false</required>
             <type>java.lang.Object</type>
-        </attribute>        
+        </attribute>        -->
     </tag>
 
     <!-- Behaviors -->
@@ -2644,9 +2644,17 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[User time zone to convert start / end dates for displaying. Time zone is useful because dates are normally stored in UTC on the server-side, but should be displayed in browser in user local time zone. The attribute can be either a String or TimeZone object. If no time zone is provided, the used time zone is TimeZone.getDefault().]]>
+                <![CDATA[Target time zone to convert start / end dates for displaying. Time zone is useful because dates are normally stored in UTC on the server-side, but should be displayed in browser in user local time zone. The attribute can be either a String or TimeZone object. If no time zone is provided, the used time zone is TimeZone.getDefault() from the J2EE server.]]>
             </description>
             <name>timeZone</name>
+            <required>false</required>
+            <type>java.lang.Object</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Time zone that the user's browser / PC is running in. Allows the correct conversion of start / end dates to the target timeZone for displaying. The attribute can be either a String or TimeZone object. If no browserTZ is provided, the used time zone is the same as target timeZone.]]>
+            </description>
+            <name>browserTZ</name>
             <required>false</required>
             <type>java.lang.Object</type>
         </attribute>


### PR DESCRIPTION
Update to timeline to correctly respect timezones and avoid offset problems. Will display events correctly positioned in alternate target timeZones. Requires a new parameter "browserTZ" to do the translation. BrowserTZ should be specified whenever Timezone is used. If not specified, defaults to same as TimeZone. Apologies but the changes were built against a 0.7.1 baseline. 
