### PR TITLE
Fix of the problem when the first row in Excel has a wrong index

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/exporter/ExcelExporter.java
+++ b/src/main/java/org/primefaces/extensions/component/exporter/ExcelExporter.java
@@ -600,7 +600,7 @@ public class ExcelExporter extends Exporter {
             for (UIComponent component : headerComponentList) {
                 if (component instanceof org.primefaces.component.row.Row) {
                     org.primefaces.component.row.Row row = (org.primefaces.component.row.Row) component;
-                    int sheetRowIndex = sheet.getLastRowNum() + 1;
+                    int sheetRowIndex = sheet.getPhysicalNumberOfRows() > 0 ? sheet.getLastRowNum() + 1 : 0;
                     Row xlRow = sheet.createRow(sheetRowIndex);
                     int i = 0;
                     for (UIComponent rowComponent : row.getChildren()) {
@@ -875,7 +875,7 @@ public class ExcelExporter extends Exporter {
 
     protected void addColumnFacets(SubTable table, Sheet sheet, ColumnType columnType) {
 
-        int sheetRowIndex = sheet.getLastRowNum() + 1;
+        int sheetRowIndex = sheet.getPhysicalNumberOfRows() > 0 ? sheet.getLastRowNum() + 1 : 0;
         Row rowHeader = sheet.createRow(sheetRowIndex);
 
         for (UIColumn col : table.getColumns()) {


### PR DESCRIPTION
When the table doesn't contain any header then the first row should have index=1 (in Excel). But we cannot detect if the sheet is empty or there is only one row with index=0 with getLastRowNum function. So in this case we have to use getPhysicalNumberOfRows function and then we are able to detect if the sheet is empty or not.
