### PR TITLE
[BUG FIX] CKEditor toolbar should be initialized by JS Array, instead of...

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/widget.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/widget.js
@@ -83,7 +83,11 @@ PrimeFacesExt.widget.CKEditor = PrimeFaces.widget.DeferredWidget.extend({
 			this.options.theme = this.cfg.theme;
 		}
 		if (this.cfg.toolbar) {
-			this.options.toolbar = this.cfg.toolbar;
+			if (!(this.cfg.toolbar instanceof Array)) {
+				this.options.toolbar = eval(this.cfg.toolbar);
+			} else {
+				this.options.toolbar = this.cfg.toolbar;
+			}
 		}
 		if (this.cfg.readOnly) {
 			this.options.readOnly = this.cfg.readOnly;


### PR DESCRIPTION
... literal string

Related issues:
- primefaces-extensions/primefaces-extensions.github.com#238
- [showcase](http://www.primefaces.org/showcase-ext/sections/ckEditor/customToolbar.jsf)
