### PR TITLE
Added missing height property to knob component

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/knob/Knob.java
+++ b/src/main/java/org/primefaces/extensions/component/knob/Knob.java
@@ -42,6 +42,7 @@ public class Knob extends UIInput implements Widget, ClientBehaviorHolder {
         showLabel,
         labelTemplate,
         onchange,
+        height,
         width,
         step,
         min,
@@ -113,6 +114,14 @@ public class Knob extends UIInput implements Widget, ClientBehaviorHolder {
 
 	public void setStep(int step) {
 		this.getStateHelper().put(PropertyKeys.step, step);
+	}
+	
+	public Object getHeight() {
+		return this.getStateHelper().eval(PropertyKeys.height);
+	}
+	
+	public void setHeight(Object height) {
+		this.getStateHelper().put(PropertyKeys.height, height);
 	}
 
 	public Object getWidth() {

--- a/src/main/java/org/primefaces/extensions/component/knob/KnobRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/knob/KnobRenderer.java
@@ -56,6 +56,10 @@ public class KnobRenderer extends CoreRenderer {
 		if (knob.getWidth() != null) {
 			writer.writeAttribute("data-width", knob.getWidth().toString(), null);
 		}
+		
+		if (knob.getHeight() != null) {
+			writer.writeAttribute("data-height", knob.getHeight().toString(), null);
+		}
 
 		writer.writeAttribute("class", "knob", null);
 

--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -4868,8 +4868,14 @@ This global setting "editable" can be overwritten for individual events by setti
             <type>java.lang.Float</type>
         </attribute>
         <attribute>
-            <description><![CDATA[Widht of the component]]></description>
+            <description><![CDATA[Width of the component]]></description>
             <name>width</name>
+            <required>false</required>
+            <type>java.lang.Object</type>
+        </attribute>
+        <attribute>
+            <description><![CDATA[Height of the component]]></description>
+            <name>height</name>
             <required>false</required>
             <type>java.lang.Object</type>
         </attribute>


### PR DESCRIPTION
The knob component is missing a height property to match the data-height property of the Knob jQuery plugin. This property isn't explicitly documented on the documentation site, but is used as part of the "big" example. Setting the height is necessary for large knobs or else the result will appear cut off.

`<pe:knob/>` using a width setting of 500 and no height specified
![knob_cutoff](https://cloud.githubusercontent.com/assets/232148/4348781/a34c3234-419b-11e4-9f6c-41a79e8fd66c.png)
