### PR TITLE
Update primefaces-extensions.taglib.xml

### DIFF
--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -3686,9 +3686,9 @@ This global setting "editable" can be overwritten for individual events by setti
             <type>java.lang.Boolean</type>
         </attribute>
         <attribute>
-            <description><![CDATA[Defines if the input is readOnly.]]>
+            <description><![CDATA[Defines if the input is readonly.]]>
             </description>
-            <name>readOnly</name>
+            <name>readonly</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>


### PR DESCRIPTION
readonly is inherited from HtmlInputText, therefore not camel cased. (other readOnlys might require review as well)
