### PR TITLE
improve readability by using more specific interfaces instead of generic Map

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/importconstants/ImportConstantsTagHandler.java
+++ b/src/main/java/org/primefaces/extensions/component/importconstants/ImportConstantsTagHandler.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.el.ELContext;
 import javax.el.ExpressionFactory;
@@ -46,8 +47,8 @@ import org.primefaces.extensions.util.ClassUtils;
  */
 public class ImportConstantsTagHandler extends TagHandler {
 
-	private static final Map<ClassLoader, Map<Class<?>, Map<String, Object>>> CACHE =
-			new ConcurrentHashMap<ClassLoader, Map<Class<?>, Map<String, Object>>>();
+	private static final ConcurrentMap<ClassLoader, ConcurrentMap<Class<?>, Map<String, Object>>> CACHE =
+			new ConcurrentHashMap<ClassLoader, ConcurrentMap<Class<?>, Map<String, Object>>>();
 
 	private final TagAttribute classNameTagAttribute;
 	private final TagAttribute varTagAttribute;
@@ -125,7 +126,7 @@ public class ImportConstantsTagHandler extends TagHandler {
 			CACHE.put(classLoader, new ConcurrentHashMap<Class<?>, Map<String,Object>>());
 		}
 
-		final Map<Class<?>, Map<String, Object>> cache = CACHE.get(classLoader);
+		final ConcurrentMap<Class<?>, Map<String, Object>> cache = CACHE.get(classLoader);
 
 		final Map<String, Object> constants;
 

--- a/src/main/java/org/primefaces/extensions/component/importenum/ImportEnumTagHandler.java
+++ b/src/main/java/org/primefaces/extensions/component/importenum/ImportEnumTagHandler.java
@@ -21,6 +21,7 @@ package org.primefaces.extensions.component.importenum;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.el.ELContext;
 import javax.el.ExpressionFactory;
@@ -46,7 +47,8 @@ public class ImportEnumTagHandler extends TagHandler {
 
 	private static final String DEFAULT_ALL_SUFFIX = "ALL_VALUES";
 
-	private static final Map<ClassLoader, Map<Class<?>, Map<String, Object>>> CACHE = new ConcurrentHashMap<ClassLoader, Map<Class<?>, Map<String, Object>>>();
+	private static final ConcurrentMap<ClassLoader, ConcurrentMap<Class<?>, Map<String, Object>>> CACHE =
+	    new ConcurrentHashMap<ClassLoader, ConcurrentMap<Class<?>, Map<String, Object>>>();
 
 	private final TagAttribute typeTagAttribute;
 	private final TagAttribute varTagAttribute;
@@ -128,7 +130,7 @@ public class ImportEnumTagHandler extends TagHandler {
 				CACHE.put(classLoader, new ConcurrentHashMap<Class<?>, Map<String, Object>>());
 			}
 
-			final Map<Class<?>, Map<String, Object>> cache = CACHE.get(classLoader);
+			final ConcurrentMap<Class<?>, Map<String, Object>> cache = CACHE.get(classLoader);
 
 			final Map<String, Object> enums;
 


### PR DESCRIPTION
Simple change, doesn't change much, just readability. I actually wanted to use ConcurrentMap.computeIfAbsent() method but unfortunately, this is only available since Java 1.8 but Primefaces needs to support also 1.5.
