### PR TITLE
Patch for dirty- and change-events of ckEditor (PFE issue #126)

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/ckeditor/CKEditor.java
+++ b/src/main/java/org/primefaces/extensions/component/ckeditor/CKEditor.java
@@ -56,10 +56,12 @@ public class CKEditor extends HtmlInputTextarea implements ClientBehaviorHolder,
 	public static final String EVENT_FOCUS = "focus";
 	public static final String EVENT_WYSIWYG_MODE = "wysiwygMode";
 	public static final String EVENT_SOURCE_MODE = "sourceMode";
+        public static final String EVENT_DIRTY = "dirty";
+        public static final String EVENT_CHANGE = "change";
 
 	private static final Collection<String> EVENT_NAMES =
 			Collections.unmodifiableCollection(Arrays.asList(EVENT_SAVE, EVENT_INITIALIZE, EVENT_BLUR, EVENT_FOCUS,
-					EVENT_WYSIWYG_MODE, EVENT_SOURCE_MODE));
+					EVENT_WYSIWYG_MODE, EVENT_SOURCE_MODE, EVENT_DIRTY, EVENT_CHANGE));
 
 	/**
 	 * Properties that are tracked by state saving.

--- a/src/main/java/org/primefaces/extensions/component/inputnumber/InputNumberRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/inputnumber/InputNumberRenderer.java
@@ -163,7 +163,7 @@ public class InputNumberRenderer extends InputRenderer {
         }
 
         ExtWidgetBuilder wb = ExtWidgetBuilder.get(context);
-        wb.initWithDomReady(InputNumber.class.getSimpleName(), inputNumber.resolveWidgetVar(), inputNumber.getClientId(),);
+        wb.initWithDomReady(InputNumber.class.getSimpleName(), inputNumber.resolveWidgetVar(), inputNumber.getClientId());
         wb.attr("disabled", inputNumber.isDisabled())
                 .attr("valueToRender", formatForPlugin(valueToRender, inputNumber));
 

--- a/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/widget.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/widget.js
@@ -259,10 +259,8 @@ PrimeFacesExt.widget.CKEditor = PrimeFaces.widget.DeferredWidget.extend({
         }, this));
 
         this.instance.on('blur', $.proxy(function() {
-                // this.checkChange(); // editor has built in 'change on blur' check
                 this.checkDirty();
-                var editor = this.getEditorInstance();
-                editor.dirtyFired = false;
+                this.instance.dirtyFired = false;
         }, this));
     },
 
@@ -274,11 +272,10 @@ PrimeFacesExt.widget.CKEditor = PrimeFaces.widget.DeferredWidget.extend({
      */
     checkDirty : function() {
 	if (this.isDirtyEventDefined) {
-		var editor = this.getEditorInstance();
-		if (!editor.dirtyFired && editor.checkDirty()) { // checkDirty means isDirty
+		if (!this.instance.dirtyFired && this.instance.checkDirty()) { // checkDirty means isDirty
 			// fires the dirty event only once!
 			this.fireEvent('dirty');
-			editor.dirtyFired = true;
+			this.instance.dirtyFired = true;
 		}
 	}
     },


### PR DESCRIPTION
In regard to: https://github.com/primefaces-extensions/primefaces-extensions.github.com/issues/126

Hi Thomas,
I added a simple patch which uses the editor's built-in-dirty-logic (patch is based on old pfe-implementation). Behavior can be seen in the screenshot. 

![editor](https://cloud.githubusercontent.com/assets/853698/5580726/28714d1c-904f-11e4-8076-6ab013533661.jpg)
