### PR TITLE
Don't assume 1 sec passed in doStep, calculate it

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces-extensions/timer/timer.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/timer/timer.js
@@ -19,6 +19,9 @@ PrimeFacesExt.widget.Timer = PrimeFaces.widget.BaseWidget.extend({
         this.print();
 
     },
+    currentTimeInSecs: function() {
+      return parseInt((new Date()).getTime() / 1000, 10);
+    },
     print:function(){
 
         var value = this.currentTimeout;
@@ -41,7 +44,9 @@ PrimeFacesExt.widget.Timer = PrimeFaces.widget.BaseWidget.extend({
         this.jq.html(value);
     },
     doStep: function(){
-        this.currentTimeout += this.forward ? 1 : -1;
+        var seconds = this._currentTimeInSecs() - this.prevTime;
+        this.prevTime = this._currentTimeInSecs();
+        this.currentTimeout += this.forward ? seconds : (0 - seconds);
         this.print();
         if(this.cfg.ontimerstep){
             this.cfg.ontimerstep({
@@ -54,6 +59,7 @@ PrimeFacesExt.widget.Timer = PrimeFaces.widget.BaseWidget.extend({
 
         var that = this;
         var end;
+        this.prevTime = this._currentTimeInSecs();
 
         if(!this.interval){
             this.interval = setInterval(function(){


### PR DESCRIPTION
Javascript `setInterval()` notoriously unreliable at executing at a precise time (see: http://ejohn.org/blog/how-javascript-timers-work/).  `doStep()` is assuming that since the interval is 1000ms, the countdown timer has changed by 1s.  That isn't always the case.  For example, on Mac, running a timer in your browser then locking the screen can cause the timer to fall behind.

This fix adds a new function `currentTimeInSecs()`.  It is used in `start()` to store the current time as `prevTime`.  Then in `doStep()` the time passed is calculated by subtracting `prevTime` from the current time in seconds and `prevTime` gets updated.  This allows `doStep` to be missed or called later than expected without the `currentTimeout` being wrong.
