### PR TITLE
KeyFilter improvement: InputRegEx to have regEx on the whole text

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/keyfilter/KeyFilter.java
+++ b/src/main/java/org/primefaces/extensions/component/keyfilter/KeyFilter.java
@@ -62,7 +62,7 @@ public class KeyFilter extends UIComponentBase implements Widget {
 		widgetVar,
 		forValue("for"),
 		regEx,
-		regExAll,
+		inputRegEx,
 		mask,
 		testFunction,
 		preventPaste;
@@ -115,12 +115,12 @@ public class KeyFilter extends UIComponentBase implements Widget {
 		getStateHelper().put(PropertyKeys.regEx, regEx);
 	}
 
-	public String getRegExAll() {
-		return (String) getStateHelper().eval(PropertyKeys.regExAll, null);
+	public String getInputRegEx() {
+		return (String) getStateHelper().eval(PropertyKeys.inputRegEx, null);
 	}
 
-	public void setRegExAll(final String regExAll) {
-		getStateHelper().put(PropertyKeys.regExAll, regExAll);
+	public void setInputRegEx(final String inputRegEx) {
+		getStateHelper().put(PropertyKeys.inputRegEx, inputRegEx);
 	}
 
 	public String getMask() {

--- a/src/main/java/org/primefaces/extensions/component/keyfilter/KeyFilter.java
+++ b/src/main/java/org/primefaces/extensions/component/keyfilter/KeyFilter.java
@@ -62,6 +62,7 @@ public class KeyFilter extends UIComponentBase implements Widget {
 		widgetVar,
 		forValue("for"),
 		regEx,
+		regExAll,
 		mask,
 		testFunction,
 		preventPaste;
@@ -112,6 +113,14 @@ public class KeyFilter extends UIComponentBase implements Widget {
 
 	public void setRegEx(final String regEx) {
 		getStateHelper().put(PropertyKeys.regEx, regEx);
+	}
+
+	public String getRegExAll() {
+		return (String) getStateHelper().eval(PropertyKeys.regExAll, null);
+	}
+
+	public void setRegExAll(final String regExAll) {
+		getStateHelper().put(PropertyKeys.regExAll, regExAll);
 	}
 
 	public String getMask() {

--- a/src/main/java/org/primefaces/extensions/component/keyfilter/KeyFilterRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/keyfilter/KeyFilterRenderer.java
@@ -64,6 +64,8 @@ public class KeyFilterRenderer extends CoreRenderer {
 
 		if (keyFilter.getRegEx() != null) {
 			writer.write(",regEx:" + keyFilter.getRegEx());
+		} else if(keyFilter.getRegExAll() != null) {
+			writer.write(",regExAll:" + keyFilter.getRegExAll());
 		} else if (keyFilter.getMask() != null) {
 			writer.write(",mask:'" + keyFilter.getMask() + "'");
 		} else if (keyFilter.getTestFunction() != null) {

--- a/src/main/java/org/primefaces/extensions/component/keyfilter/KeyFilterRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/keyfilter/KeyFilterRenderer.java
@@ -64,8 +64,8 @@ public class KeyFilterRenderer extends CoreRenderer {
 
 		if (keyFilter.getRegEx() != null) {
 			writer.write(",regEx:" + keyFilter.getRegEx());
-		} else if(keyFilter.getRegExAll() != null) {
-			writer.write(",regExAll:" + keyFilter.getRegExAll());
+		} else if(keyFilter.getInputRegEx() != null) {
+			writer.write(",inputRegEx:" + keyFilter.getInputRegEx());
 		} else if (keyFilter.getMask() != null) {
 			writer.write(",mask:'" + keyFilter.getMask() + "'");
 		} else if (keyFilter.getTestFunction() != null) {

--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -2372,6 +2372,13 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description><![CDATA[Defines the regular expression which should be used to test the complete input.]]>
+            </description>
+            <name>regExAll</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
             <description>
                 <![CDATA[Defines the predefined mask which should be used (pint, int, pnum, num, hex, email, alpha, alphanum).]]>
             </description>

--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -2374,7 +2374,7 @@
         <attribute>
             <description><![CDATA[Defines the regular expression which should be used to test the complete input.]]>
             </description>
-            <name>regExAll</name>
+            <name>inputRegEx</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
@@ -130,25 +130,6 @@
 		});
 	};
 
-	/**
-	* Call when regExAll is define.
-	*/
-	$.fn.inputFilter = function(re)
-	{
-		var previousValue;
-		return this.on('input', function(e)
-		{
-			var ok = re.test(this.value);
-			
-			if(ok) {
-				previousValue = this.value;
-			}
-			else {
-				e.currentTarget.value = previousValue || '';
-			}
-		});
-	}
-
 	$.extend($.fn.keyfilter, {
 		defaults: {
 			masks: defaultMasks

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
@@ -136,19 +136,14 @@
 	$.fn.inputFilter = function(re)
 	{
 		var oldValue;
-		this.on('keypress', function(e){
-			oldValue = e.currentTarget.value;
-		});
-
 		return this.on('input', function(e)
 		{
-			var ok = true;
-			if (!$.isFunction(re))
-			{
-				ok = re.test(this.value);
+			var ok = re.test(this.value);
+			
+			if(ok) {
+				oldValue = this.value;
 			}
-			if(!ok)
-			{
+			else {
 				e.currentTarget.value = oldValue;
 			}
 		});

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
@@ -144,7 +144,7 @@
 				previousValue = this.value;
 			}
 			else {
-				e.currentTarget.value = previousValue;
+				e.currentTarget.value = previousValue || '';
 			}
 		});
 	}

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
@@ -135,16 +135,16 @@
 	*/
 	$.fn.inputFilter = function(re)
 	{
-		var oldValue;
+		var previousValue;
 		return this.on('input', function(e)
 		{
 			var ok = re.test(this.value);
 			
 			if(ok) {
-				oldValue = this.value;
+				previousValue = this.value;
 			}
 			else {
-				e.currentTarget.value = oldValue;
+				e.currentTarget.value = previousValue;
 			}
 		});
 	}

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
@@ -135,33 +135,21 @@
 	*/
 	$.fn.inputFilter = function(re)
 	{
-		return this.keypress(function(e)
+		var oldValue;
+		this.on('keypress', function(e){
+			oldValue = e.currentTarget.value;
+		});
+
+		return this.on('input', function(e)
 		{
-			if (e.ctrlKey || e.altKey)
+			var ok = true;
+			if (!$.isFunction(re))
 			{
-				return;
-			}
-			var k = getKey(e);
-			if($.browser.mozilla && (isNavKeyPress(e) || k == Keys.BACKSPACE || (k == Keys.DELETE && e.charCode == 0)))
-			{
-				return;
-			}
-			var c = getCharCode(e), cc = $(e.currentTarget).val() + String.fromCharCode(c), ok = true;
-			if(!$.browser.mozilla && (isSpecialKey(e) || !cc))
-			{
-				return;
-			}
-			if ($.isFunction(re))
-			{
-				ok = re.call(this, cc);
-			}
-			else
-			{
-				ok = re.test(cc);
+				ok = re.test(this.value);
 			}
 			if(!ok)
 			{
-				e.preventDefault();
+				e.currentTarget.value = oldValue;
 			}
 		});
 	}

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/0-jquery.keyfilter.js
@@ -130,6 +130,42 @@
 		});
 	};
 
+	/**
+	* Call when regExAll is define.
+	*/
+	$.fn.inputFilter = function(re)
+	{
+		return this.keypress(function(e)
+		{
+			if (e.ctrlKey || e.altKey)
+			{
+				return;
+			}
+			var k = getKey(e);
+			if($.browser.mozilla && (isNavKeyPress(e) || k == Keys.BACKSPACE || (k == Keys.DELETE && e.charCode == 0)))
+			{
+				return;
+			}
+			var c = getCharCode(e), cc = $(e.currentTarget).val() + String.fromCharCode(c), ok = true;
+			if(!$.browser.mozilla && (isSpecialKey(e) || !cc))
+			{
+				return;
+			}
+			if ($.isFunction(re))
+			{
+				ok = re.call(this, cc);
+			}
+			else
+			{
+				ok = re.test(cc);
+			}
+			if(!ok)
+			{
+				e.preventDefault();
+			}
+		});
+	}
+
 	$.extend($.fn.keyfilter, {
 		defaults: {
 			masks: defaultMasks

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/1-keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/1-keyfilter.js
@@ -35,8 +35,8 @@ PrimeFacesExt.widget.KeyFilter = PrimeFaces.widget.BaseWidget.extend({
 	applyKeyFilter : function(input, cfg) {
 		if (this.cfg.regEx) {
 			input.keyfilter(this.cfg.regEx);
-		} else if(this.cfg.regExAll) {
-			input.inputFilter(this.cfg.regExAll);
+		} else if(this.cfg.inputRegEx) {
+			input.inputFilter(this.cfg.inputRegEx);
 		} else if (this.cfg.testFunction) {
 			input.keyfilter(this.cfg.testFunction);
 		} else if (this.cfg.mask) {

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/1-keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/1-keyfilter.js
@@ -36,7 +36,17 @@ PrimeFacesExt.widget.KeyFilter = PrimeFaces.widget.BaseWidget.extend({
 		if (this.cfg.regEx) {
 			input.keyfilter(this.cfg.regEx);
 		} else if(this.cfg.inputRegEx) {
-			input.inputFilter(this.cfg.inputRegEx);
+			var inputRegEx = this.cfg.inputRegEx;
+		 	var previousInputValue = '';
+			input.on('input', function(e) {
+				var ok = inputRegEx.test(this.value);
+				if(ok) {
+					previousInputValue = this.value;
+				}
+				else {
+					this.value = previousInputValue;
+				}
+			});
 		} else if (this.cfg.testFunction) {
 			input.keyfilter(this.cfg.testFunction);
 		} else if (this.cfg.mask) {

--- a/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/1-keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/keyfilter/1-keyfilter.js
@@ -35,6 +35,8 @@ PrimeFacesExt.widget.KeyFilter = PrimeFaces.widget.BaseWidget.extend({
 	applyKeyFilter : function(input, cfg) {
 		if (this.cfg.regEx) {
 			input.keyfilter(this.cfg.regEx);
+		} else if(this.cfg.regExAll) {
+			input.inputFilter(this.cfg.regExAll);
 		} else if (this.cfg.testFunction) {
 			input.keyfilter(this.cfg.testFunction);
 		} else if (this.cfg.mask) {


### PR DESCRIPTION
I create a new Parameter to add regEx like `/^[0-9]{0,3}((\\.|,)[0-9]{0,6}|)$/`.
- Parameter inputRegEx.
- Function inputFilter based on event Jquery 'input'.
