### PR TITLE
Added attribute 'zoom' for documentViewer

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/documentviewer/DocumentViewer.java
+++ b/src/main/java/org/primefaces/extensions/component/documentviewer/DocumentViewer.java
@@ -23,7 +23,8 @@ public class DocumentViewer extends UIGraphic {
         library,
         cache,
         page,
-        locale;
+        locale,
+		zoom;
     }
 
     public DocumentViewer(){
@@ -98,4 +99,11 @@ public class DocumentViewer extends UIGraphic {
 		getStateHelper().put(PropertyKeys.locale, _locale);
 	}
 
+	public void setZoom(String zoom) {
+		getStateHelper().put(PropertyKeys.zoom, zoom);
+	}
+	
+	public String getZoom() {
+		return (String) getStateHelper().eval(PropertyKeys.zoom, null);
+	}
 }

--- a/src/main/java/org/primefaces/extensions/component/documentviewer/DocumentViewerRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/documentviewer/DocumentViewerRenderer.java
@@ -68,6 +68,10 @@ public class DocumentViewerRenderer extends CoreRenderer {
         if(documentViewer.getPage() != null){
             params.add("page="+documentViewer.getPage());
         }
+		
+		if(documentViewer.getZoom() != null){
+            params.add("zoom=" + documentViewer.getZoom());
+        }
 
         if(!params.isEmpty()){
             return "#" + StringUtils.join(params, "&");

--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -4675,6 +4675,12 @@ This global setting "editable" can be overwritten for individual events by setti
             <required>false</required>
             <type>java.lang.Object</type>
         </attribute>
+		<attribute>
+            <description><![CDATA[Start page of the document.]]></description>
+            <name>zoom</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
         <attribute>
             <description><![CDATA[Name of the document]]></description>
             <name>name</name>


### PR DESCRIPTION
Added the attribute 'zoom' for documentViewer. Attributes value is added in the iframes url like the 'page' attribute. Possible values for the attribute can be taken from the pdf.js documentation. E. g. numerical values for the zoom like '75' or 'page-width', 'page-height', 'page-fit' or 'auto'. If the 'zoom' attribute is not specified the documentViewer behaviour does not change.
