### PR TITLE
The web browser language identification codes and Java locale values aren't the same in most cases.

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/documentviewer/DocumentViewerRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/documentviewer/DocumentViewerRenderer.java
@@ -62,7 +62,7 @@ public class DocumentViewerRenderer extends CoreRenderer {
     private String generateHashString(DocumentViewer documentViewer,FacesContext context) {
 
         List<String> params = new ArrayList<String>(1);
-        params.add("locale=" + getCalculatedLocale(documentViewer, context));
+        params.add("locale=" + getCalculatedLocale(documentViewer, context).toString().replaceAll( "_", "-" ));
         if(documentViewer.getPage() != null){
             params.add("page="+documentViewer.getPage());
         }
@@ -91,7 +91,7 @@ public class DocumentViewerRenderer extends CoreRenderer {
             if(locale instanceof Locale){
                 return (Locale) locale;
             }else if(locale instanceof String){
-                return ComponentUtils.toLocale((String) locale);
+                return ComponentUtils.toLocale(((String) locale).replaceAll( "-", "_" ));
             }else{
                 throw new IllegalArgumentException("Type:" + locale.getClass() + " is not a valid locale type for calendar:" + documentViewer.getClientId(context));
             }

--- a/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/app.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/app.js
@@ -10145,8 +10145,8 @@ var MAX_AUTO_SCALE = 1.25;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 4.0;
 var VIEW_HISTORY_MEMORY = 20;
-var SCALE_SELECT_CONTAINER_PADDING = 8;
-var SCALE_SELECT_PADDING = 22;
+var SCALE_SELECT_CONTAINER_PADDING = 16;
+var SCALE_SELECT_PADDING = 14;
 var THUMBNAIL_SCROLL_MARGIN = -19;
 var USE_ONLY_CSS_ZOOM = false;
 var CLEANUP_TIMEOUT = 30000;
@@ -15525,7 +15525,7 @@ window.addEventListener('localized', function localized(evt) {
     if (container.clientWidth > 0) {
       var select = document.getElementById('scaleSelect');
       select.setAttribute('style', 'min-width: inherit;');
-      var width = select.clientWidth + SCALE_SELECT_CONTAINER_PADDING;
+      var width = select.offsetWidth + SCALE_SELECT_CONTAINER_PADDING;
       select.setAttribute('style', 'min-width: ' +
                                    (width + SCALE_SELECT_PADDING) + 'px;');
       container.setAttribute('style', 'min-width: ' + width + 'px; ' +

--- a/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/app.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/app.js
@@ -771,7 +771,9 @@ document.webL10n = (function(window, document, undefined) {
             }
             if (reImport.test(line)) { // @import rule?
               match = reImport.exec(line);
-              var url = window.parent.PrimeFacesExt.getFacesResource('documentviewer/locale/' + match[1],'primefaces-extensions-uncompressed','${project.version}');
+              var url = window.parent.PrimeFaces.getFacesResource('documentviewer/locale/' + match[1],
+                    window.parent.PrimeFacesExt.RESOURCE_LIBRARY,
+                    window.parent.PrimeFacesExt.VERSION);
               loadImport(url); // load the resource synchronously
             }
           }
@@ -6111,7 +6113,9 @@ var WorkerTransport = (function WorkerTransportClosure() {
       try {
         // Some versions of FF can't create a worker on localhost, see:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-	      workerSrc = window.parent.PrimeFacesExt.getFacesResource('documentviewer/pdf.worker.js','primefaces-extensions-uncompressed','${project.version}');
+        workerSrc = window.parent.PrimeFaces.getFacesResource('documentviewer/pdf.worker.js',
+            window.parent.PrimeFacesExt.RESOURCE_LIBRARY,
+            window.parent.PrimeFacesExt.VERSION);
         var worker = new Worker(workerSrc);
         var messageHandler = new MessageHandler('main', worker);
         this.messageHandler = messageHandler;
@@ -10141,8 +10145,8 @@ var MAX_AUTO_SCALE = 1.25;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 4.0;
 var VIEW_HISTORY_MEMORY = 20;
-var SCALE_SELECT_CONTAINER_PADDING = 16;
-var SCALE_SELECT_PADDING = 14;
+var SCALE_SELECT_CONTAINER_PADDING = 8;
+var SCALE_SELECT_PADDING = 22;
 var THUMBNAIL_SCROLL_MARGIN = -19;
 var USE_ONLY_CSS_ZOOM = false;
 var CLEANUP_TIMEOUT = 30000;
@@ -15521,7 +15525,7 @@ window.addEventListener('localized', function localized(evt) {
     if (container.clientWidth > 0) {
       var select = document.getElementById('scaleSelect');
       select.setAttribute('style', 'min-width: inherit;');
-      var width = select.offsetWidth + SCALE_SELECT_CONTAINER_PADDING;
+      var width = select.clientWidth + SCALE_SELECT_CONTAINER_PADDING;
       select.setAttribute('style', 'min-width: ' +
                                    (width + SCALE_SELECT_PADDING) + 'px;');
       container.setAttribute('style', 'min-width: ' + width + 'px; ' +

--- a/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/app.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/app.js
@@ -10146,7 +10146,7 @@ var MIN_SCALE = 0.25;
 var MAX_SCALE = 4.0;
 var VIEW_HISTORY_MEMORY = 20;
 var SCALE_SELECT_CONTAINER_PADDING = 16;
-var SCALE_SELECT_PADDING = 14;
+var SCALE_SELECT_PADDING = 30;
 var THUMBNAIL_SCROLL_MARGIN = -19;
 var USE_ONLY_CSS_ZOOM = false;
 var CLEANUP_TIMEOUT = 30000;
@@ -15525,7 +15525,7 @@ window.addEventListener('localized', function localized(evt) {
     if (container.clientWidth > 0) {
       var select = document.getElementById('scaleSelect');
       select.setAttribute('style', 'min-width: inherit;');
-      var width = select.offsetWidth + SCALE_SELECT_CONTAINER_PADDING;
+      var width = select.clientWidth + SCALE_SELECT_CONTAINER_PADDING;
       select.setAttribute('style', 'min-width: ' +
                                    (width + SCALE_SELECT_PADDING) + 'px;');
       container.setAttribute('style', 'min-width: ' + width + 'px; ' +

--- a/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/app.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/app.js
@@ -771,9 +771,7 @@ document.webL10n = (function(window, document, undefined) {
             }
             if (reImport.test(line)) { // @import rule?
               match = reImport.exec(line);
-              var url = window.parent.PrimeFaces.getFacesResource('documentviewer/locale/' + match[1],
-                    window.parent.PrimeFacesExt.RESOURCE_LIBRARY,
-                    window.parent.PrimeFacesExt.VERSION);
+              var url = window.parent.PrimeFacesExt.getFacesResource('documentviewer/locale/' + match[1],'primefaces-extensions-uncompressed','${project.version}');
               loadImport(url); // load the resource synchronously
             }
           }
@@ -6113,9 +6111,7 @@ var WorkerTransport = (function WorkerTransportClosure() {
       try {
         // Some versions of FF can't create a worker on localhost, see:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=683280
-        workerSrc = window.parent.PrimeFaces.getFacesResource('documentviewer/pdf.worker.js',
-            window.parent.PrimeFacesExt.RESOURCE_LIBRARY,
-            window.parent.PrimeFacesExt.VERSION);
+	      workerSrc = window.parent.PrimeFacesExt.getFacesResource('documentviewer/pdf.worker.js','primefaces-extensions-uncompressed','${project.version}');
         var worker = new Worker(workerSrc);
         var messageHandler = new MessageHandler('main', worker);
         this.messageHandler = messageHandler;
@@ -10145,8 +10141,8 @@ var MAX_AUTO_SCALE = 1.25;
 var MIN_SCALE = 0.25;
 var MAX_SCALE = 4.0;
 var VIEW_HISTORY_MEMORY = 20;
-var SCALE_SELECT_CONTAINER_PADDING = 8;
-var SCALE_SELECT_PADDING = 22;
+var SCALE_SELECT_CONTAINER_PADDING = 16;
+var SCALE_SELECT_PADDING = 14;
 var THUMBNAIL_SCROLL_MARGIN = -19;
 var USE_ONLY_CSS_ZOOM = false;
 var CLEANUP_TIMEOUT = 30000;
@@ -15525,7 +15521,7 @@ window.addEventListener('localized', function localized(evt) {
     if (container.clientWidth > 0) {
       var select = document.getElementById('scaleSelect');
       select.setAttribute('style', 'min-width: inherit;');
-      var width = select.clientWidth + SCALE_SELECT_CONTAINER_PADDING;
+      var width = select.offsetWidth + SCALE_SELECT_CONTAINER_PADDING;
       select.setAttribute('style', 'min-width: ' +
                                    (width + SCALE_SELECT_PADDING) + 'px;');
       container.setAttribute('style', 'min-width: ' + width + 'px; ' +

--- a/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/locale/locales.txt
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/locale/locales.txt
@@ -61,6 +61,9 @@
 [el]
 @import url(el.locale.txt)
 
+[en]
+@import url(en-GB.locale.txt)
+
 [en-GB]
 @import url(en-GB.locale.txt)
 
@@ -72,6 +75,9 @@
 
 [eo]
 @import url(eo.locale.txt)
+
+[es]
+@import url(es-ES.locale.txt)
 
 [es-AR]
 @import url(es-AR.locale.txt)
@@ -219,6 +225,9 @@
 
 [pl]
 @import url(pl.locale.txt)
+
+[pt]
+@import url(pt-PT.locale.txt)
 
 [pt-BR]
 @import url(pt-BR.locale.txt)


### PR DESCRIPTION
Example:
- Spanish Web browser language identification codes: es or es-ES
- Spanish Java locale : es or es_ES.

When I translate from web code to Java locale, we have to change the '-' with '_' character.
When I translate from Java locale to web code, we have to change the '_' with '-' character.
