### PR TITLE
throw faces error on the server side if calculator is not attached or…

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/calculator/CalculatorRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/calculator/CalculatorRenderer.java
@@ -19,7 +19,9 @@ package org.primefaces.extensions.component.calculator;
 
 import java.io.IOException;
 
+import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
+import javax.faces.component.UIInput;
 import javax.faces.context.FacesContext;
 
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +53,11 @@ public class CalculatorRenderer extends CoreRenderer {
       String target = SearchExpressionFacade.resolveClientIds(context, calculator, calculator.getFor());
       if (isValueBlank(target)) {
          target = calculator.getParent().getClientId(context);
+      }
+      
+      UIComponent targetComponent = SearchExpressionFacade.resolveComponent(context, calculator, target);
+      if(!(targetComponent instanceof UIInput)) {
+	  throw new FacesException("Calculator must use for=\"target\" or be nested inside an input!");
       }
 
       final WidgetBuilder wb = getWidgetBuilder(context);


### PR DESCRIPTION
… is not a child a Input Component

Resolve https://github.com/primefaces-extensions/primefaces-extensions.github.com/issues/456

Test code:

```html
<html xmlns="http://www.w3.org/1999/xhtml"
	xmlns:h="http://xmlns.jcp.org/jsf/html"
	xmlns:f="http://xmlns.jcp.org/jsf/core"
	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
	xmlns:p="http://primefaces.org/ui"
	xmlns:pe="http://primefaces.org/ui/extensions">
<ui:composition>

	<h:head>
	</h:head>

	<h:body>
		<!-- <p:inputText id="test"></p:inputText>
		<pe:calculator for="test"></pe:calculator> -->
		
		<pe:calculator></pe:calculator>
	</h:body>

</ui:composition>
</html>
```

![image](https://cloud.githubusercontent.com/assets/10467831/26034889/7d10afcc-3889-11e7-8432-9376294d50e7.png)


and this:

```xhtml
<html xmlns="http://www.w3.org/1999/xhtml"
	xmlns:h="http://xmlns.jcp.org/jsf/html"
	xmlns:f="http://xmlns.jcp.org/jsf/core"
	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
	xmlns:p="http://primefaces.org/ui"
	xmlns:pe="http://primefaces.org/ui/extensions">
<ui:composition>

	<h:head>
	</h:head>

	<h:body>
		<p:inputText id="test"></p:inputText>
		<pe:calculator for="test"></pe:calculator>
		
		<!-- <pe:calculator></pe:calculator> -->
	</h:body>

</ui:composition>
</html>
```


![image](https://cloud.githubusercontent.com/assets/10467831/26034897/a4bd7802-3889-11e7-811d-b9fcb540a1e4.png)
