### PR TITLE
Fix #507 - address Error code 'editor-destroy-iframe' warning

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/widget.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/widget.js
@@ -156,7 +156,7 @@ PrimeFaces.widget.ExtCKEditor = PrimeFaces.widget.DeferredWidget.extend({
                 var oldInstance = CKEDITOR.instances[this.id];
                 if (oldInstance) {
                     try {
-                        oldInstance.destroy(true);
+                        this.destroyOnUpdate(oldInstance);
                     } catch (err) {
                         if (window.console && console.log) {
                             console.log('CKEditor threw an error while destroying the old instance: ' + err);
@@ -280,6 +280,34 @@ PrimeFaces.widget.ExtCKEditor = PrimeFaces.widget.DeferredWidget.extend({
         
         // let the widget know we are done initializing
         this.initializing = false;
+    },
+
+    /**
+     * This method will be called to clean up the old instance on update
+     *
+     * @private
+     */
+    destroyOnUpdate: function( instance ) {
+        if(instance) {
+            instance.fire( 'beforeDestroy' );
+    
+            if ( instance.filter ) {
+                instance.filter.destroy();
+                delete instance.filter;
+            }
+    
+            delete instance.activeFilter;
+    
+            instance.status = 'destroyed';
+    
+            instance.fire( 'destroy' );
+    
+            // Plug off all listeners to prevent any further events firing.
+            instance.removeAllListeners();
+    
+            CKEDITOR.remove( instance );
+            CKEDITOR.fire( 'instanceDestroyed', null, instance );
+        }
     },
 
     /**


### PR DESCRIPTION
Fix https://github.com/primefaces-extensions/primefaces-extensions.github.com/issues/507


Background: 

CKEditor needs to be destroyed when it is in DOM. However, due to the mechanism of view update of Primefaces, the old instance was partially destroyed by  ` $(PrimeFaces.escapeClientId(id)).replaceWith(content);` in core.js in Primefaces before hitting the default destroy function.

So the solution is to use a  custom destroy function on render stage using CKeditor's destroy function as a reference.

Here is the original function in CKEditor

```js
/**
		 * Destroys the editor instance, releasing all resources used by it.
		 * If the editor replaced an element, the element will be recovered.
		 *
		 *		alert( CKEDITOR.instances.editor1 ); // e.g. object
		 *		CKEDITOR.instances.editor1.destroy();
		 *		alert( CKEDITOR.instances.editor1 ); // undefined
		 *
		 * @param {Boolean} [noUpdate] If the instance is replacing a DOM
		 * element, this parameter indicates whether or not to update the
		 * element with the instance content.
		 */
		destroy: function( noUpdate ) {
			this.fire( 'beforeDestroy' );

			!noUpdate && updateEditorElement.call( this );

			this.editable( null );

			if ( this.filter ) {
				this.filter.destroy();
				delete this.filter;
			}

			delete this.activeFilter;

			this.status = 'destroyed';

			this.fire( 'destroy' );

			// Plug off all listeners to prevent any further events firing.
			this.removeAllListeners();

			CKEDITOR.remove( this );
			CKEDITOR.fire( 'instanceDestroyed', null, this );
		},
```

The key here is to get rid of `this.editable( null );` which triggers the warning as the DOM element has gone.

---

After this patch, no warning will be thrown

![snapshot1](https://user-images.githubusercontent.com/10467831/32984981-c8a4ef40-cc75-11e7-8535-ee9a3e233485.png)

