### PR TITLE
Fix #591: Sheet: Column filter focus problem

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces-extensions/sheet/1-sheet.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/sheet/1-sheet.js
@@ -423,12 +423,15 @@ PrimeFaces.widget.ExtSheet = PrimeFaces.widget.DeferredWidget.extend({
         // this causes us to lose focus, so we need to refocus
         // we need to prevent recursion with this hack
         sheet.focusing = true;
-        sheet.focusInput.val($(inp).attr('id'));
         sheet.ht.destroyEditor(true);
-        $(inp).focus();
-        sheet.focusing = false;
+        // for some reason does not work when focused immediately,
+        setTimeout(function () {
+            sheet.focusInput.val($(inp).attr('id'));
+            $(inp).focus();
+            sheet.focusing = false;
 
-        sheet.filter();
+            sheet.filter();
+        },100);
     },
 
     // remove focused filter tracking when tabbing off


### PR DESCRIPTION
Proposed fix for "#591: Sheet: Column filter focus problem".
I'm not a fan of the used solution as setTimeout is in my opinion almost always a work-around instead of a fix.
However, I've done some testing and everything seems to work correctly with this in place. 