### PR TITLE
#569: use getWidgetBuilder(context); from CoreRenderer

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/ckeditor/CKEditorRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/ckeditor/CKEditorRenderer.java
@@ -23,7 +23,6 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.convert.Converter;
 
-import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -94,7 +93,7 @@ public class CKEditorRenderer extends InputRenderer {
     }
 
     protected void encodeScript(final FacesContext context, final CKEditor ckEditor) throws IOException {
-        final WidgetBuilder wb = RequestContext.getCurrentInstance().getWidgetBuilder();
+        final WidgetBuilder wb = getWidgetBuilder(context);
         wb.initWithDomReady("ExtCKEditor", ckEditor.resolveWidgetVar(), ckEditor.getClientId());
         wb.attr("height", ckEditor.getHeight())
                     .attr("width", ckEditor.getWidth())

--- a/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirrorRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirrorRenderer.java
@@ -25,7 +25,6 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.convert.Converter;
 import javax.faces.event.PhaseId;
 
-import org.primefaces.context.RequestContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.extensions.event.CompleteEvent;
 import org.primefaces.renderkit.InputRenderer;
@@ -115,7 +114,7 @@ public class CodeMirrorRenderer extends InputRenderer {
     }
 
     protected void encodeScript(final FacesContext context, final CodeMirror codeMirror) throws IOException {
-        WidgetBuilder wb = RequestContext.getCurrentInstance().getWidgetBuilder();
+        WidgetBuilder wb = getWidgetBuilder(context);
         wb.initWithDomReady("ExtCodeMirror", codeMirror.resolveWidgetVar(), codeMirror.getClientId());
         wb.attr("theme", codeMirror.getTheme())
                     .attr("mode", codeMirror.getMode())

--- a/src/main/java/org/primefaces/extensions/component/gchart/GChartRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/gchart/GChartRenderer.java
@@ -22,7 +22,6 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
 import org.apache.commons.lang3.StringUtils;
-import org.primefaces.context.RequestContext;
 import org.primefaces.extensions.component.gchart.model.GChartModel;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.WidgetBuilder;
@@ -67,7 +66,7 @@ public class GChartRenderer extends CoreRenderer {
             apiKey = getApiKey(context, chart);
         }
 
-        final WidgetBuilder wb = RequestContext.getCurrentInstance().getWidgetBuilder();
+        final WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("ExtGChart", widgetVar, clientId)
                     .attr("chart", ((GChartModel) chart.getValue()).toJson())
                     .attr("title", chart.getTitle())

--- a/src/main/java/org/primefaces/extensions/component/imageareaselect/ImageAreaSelectRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/imageareaselect/ImageAreaSelectRenderer.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 
-import org.primefaces.context.RequestContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.WidgetBuilder;
@@ -43,7 +42,7 @@ public class ImageAreaSelectRenderer extends CoreRenderer {
     public void encodeEnd(final FacesContext context, final UIComponent component) throws IOException {
         ImageAreaSelect imageAreaSelect = (ImageAreaSelect) component;
 
-        WidgetBuilder wb = RequestContext.getCurrentInstance().getWidgetBuilder();
+        WidgetBuilder wb = getWidgetBuilder(context);
         wb.initWithDomReady("ExtImageAreaSelect", imageAreaSelect.resolveWidgetVar(), imageAreaSelect.getClientId());
         wb.attr("target", SearchExpressionFacade.resolveClientId(context, imageAreaSelect, imageAreaSelect.getFor()))
                     .attr("aspectRatio", imageAreaSelect.getAspectRatio())

--- a/src/main/java/org/primefaces/extensions/component/imagerotateandresize/ImageRotateAndResizeRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/imagerotateandresize/ImageRotateAndResizeRenderer.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 
-import org.primefaces.context.RequestContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.WidgetBuilder;
@@ -43,7 +42,7 @@ public class ImageRotateAndResizeRenderer extends CoreRenderer {
     public void encodeEnd(final FacesContext context, final UIComponent component) throws IOException {
         final ImageRotateAndResize imageRotateAndResize = (ImageRotateAndResize) component;
 
-        WidgetBuilder wb = RequestContext.getCurrentInstance().getWidgetBuilder();
+        WidgetBuilder wb = getWidgetBuilder(context);
         wb.initWithDomReady("ExtImageRotateAndResize", imageRotateAndResize.resolveWidgetVar(), imageRotateAndResize.getClientId());
         wb.attr("target", SearchExpressionFacade.resolveClientId(context, imageRotateAndResize, imageRotateAndResize.getFor()));
 

--- a/src/main/java/org/primefaces/extensions/component/timer/TimerRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/timer/TimerRenderer.java
@@ -108,7 +108,7 @@ public class TimerRenderer extends CoreRenderer {
                     .params(timer)
                     .build();
 
-        final WidgetBuilder wb = RequestContext.getCurrentInstance().getWidgetBuilder();
+        final WidgetBuilder wb = getWidgetBuilder(context);
 
         wb.initWithDomReady("ExtTimer", widgetVar, clientId).attr("timeout", timer.getTimeout())
                     .attr("singleRun", timer.isSingleRun()).attr("format", timer.getFormat())

--- a/src/main/java/org/primefaces/extensions/component/tristatemanycheckbox/TriStateManyCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/tristatemanycheckbox/TriStateManyCheckboxRenderer.java
@@ -35,7 +35,6 @@ import javax.faces.convert.ConverterException;
 import javax.faces.model.SelectItem;
 
 import org.primefaces.component.selectmanycheckbox.SelectManyCheckbox;
-import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
@@ -274,7 +273,7 @@ public class TriStateManyCheckboxRenderer extends SelectManyRenderer {
     }
 
     protected void encodeScript(FacesContext context, TriStateManyCheckbox checkbox) throws IOException {
-        WidgetBuilder wb = RequestContext.getCurrentInstance().getWidgetBuilder();
+        WidgetBuilder wb = getWidgetBuilder(context);
         wb.initWithDomReady("ExtTriStateManyCheckbox", checkbox.resolveWidgetVar(), checkbox.getClientId());
         encodeClientBehaviors(context, checkbox);
         wb.finish();

--- a/src/main/java/org/primefaces/extensions/component/waypoint/WaypointRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/waypoint/WaypointRenderer.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 
-import org.primefaces.context.RequestContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.expression.SearchExpressionHint;
 import org.primefaces.renderkit.CoreRenderer;
@@ -50,7 +49,7 @@ public class WaypointRenderer extends CoreRenderer {
         final String target = SearchExpressionFacade.resolveClientIds(fc, waypoint, waypoint.getFor(),
                     SearchExpressionHint.PARENT_FALLBACK);
 
-        final WidgetBuilder wb = RequestContext.getCurrentInstance().getWidgetBuilder();
+        final WidgetBuilder wb = getWidgetBuilder(fc);
         wb.initWithDomReady("ExtWaypoint", waypoint.resolveWidgetVar(), waypoint.getClientId(fc));
         wb.attr("target", target);
         wb.attr("continuous", waypoint.isContinuous());


### PR DESCRIPTION
#569: in PrimeFaces 6.3-SNAPSHOT the RequestScope is replaced by the PrimeRequestScope,

to reduce usage of RequestScope replace
RequestContext.getCurrentInstance().getWidgetBuilder();
by
getWidgetBuilder(context);
in Renderer