### PR TITLE
Fix #713 Sheet: Filtering and dynamic columns not working together

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
+++ b/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
@@ -230,7 +230,7 @@ public class Sheet extends SheetBase {
      */
     public void resetSort() {
         // Set to null to restore initial sort order specified by sortBy
-        getStateHelper().put(PropertyKeys.currentSortBy, null);
+        getStateHelper().put(PropertyKeys.currentSortBy.name(), null);
 
         final String origSortOrder = (String) getStateHelper().get(PropertyKeys.origSortOrder);
         if (origSortOrder != null) {

--- a/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
+++ b/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
@@ -229,9 +229,8 @@ public class Sheet extends SheetBase {
      * Resets the sorting to the originally specified values (if any)
      */
     public void resetSort() {
-        final ValueExpression origSortBy = (ValueExpression) getStateHelper().get(PropertyKeys.origSortBy);
-        // Set sort by even if null to restore to initial sort order.
-        setSortByValueExpression(origSortBy);
+        // Set to null to restore initial sort order specified by sortBy
+        getStateHelper().put(PropertyKeys.currentSortBy, null);
 
         final String origSortOrder = (String) getStateHelper().get(PropertyKeys.origSortOrder);
         if (origSortOrder != null) {
@@ -262,7 +261,8 @@ public class Sheet extends SheetBase {
     /**
      * Updates a submitted value.
      *
-     * @param row
+     * @param context
+     * @param rowKey
      * @param col
      * @param value
      */
@@ -273,7 +273,7 @@ public class Sheet extends SheetBase {
     /**
      * Retrieves the submitted value for the row and col.
      *
-     * @param row
+     * @param rowKey
      * @param col
      * @return
      */
@@ -295,7 +295,7 @@ public class Sheet extends SheetBase {
     /**
      * Retrieves the submitted value for the rowKey and col.
      *
-     * @param row
+     * @param rowKey
      * @param col
      * @return
      */
@@ -420,6 +420,31 @@ public class Sheet extends SheetBase {
      * @return
      */
     public int getSortColRenderIndex() {
+        // Was the column by which to sort changed by the user, ie. is there a saved ID?
+        String currentSortById = (String) getStateHelper().get(PropertyKeys.currentSortBy.name());
+        // Otherwise, did the user specify a valid column ID for the sortBy attribute?
+        if (StringUtils.isEmpty(currentSortById)) {
+            final Object sortBy = getStateHelper().eval(PropertyKeys.sortBy.name());
+            if (sortBy instanceof String) {
+                currentSortById = (String) sortBy;
+            }
+        }
+        if (StringUtils.isNotEmpty(currentSortById)) {
+            int colIdx = 0;
+            for (final SheetColumn column : getColumns()) {
+                if (!column.isRendered()) {
+                    continue;
+                }
+
+                if (currentSortById.equals(column.getId())) {
+                    return colIdx;
+                }
+                colIdx++;
+            }
+        }
+
+        // Otherwise, fall back to the previous behavior of searching for the column
+        // by its value expression
         final ValueExpression veSortBy = getValueExpression(PropertyKeys.sortBy.name());
         if (veSortBy == null) {
             return -1;
@@ -540,7 +565,18 @@ public class Sheet extends SheetBase {
             filteredList.addAll(values);
         }
 
-        final ValueExpression veSortBy = getValueExpression(PropertyKeys.sortBy.name());
+        // Sort by the saved column. When none was saved, sort by the "sortBy" attribute of the sheet.
+        final int sortByIdx = getSortColRenderIndex();
+        final SheetColumn currentSortByColumn = sortByIdx >= 0 ? getColumns().get(sortByIdx) : null;
+        final ValueExpression currentSortByVe = currentSortByColumn != null ? currentSortByColumn.getValueExpression(
+            PropertyKeys.sortBy.name()) : null;
+        final ValueExpression veSortBy;
+        if (currentSortByVe != null) {
+            veSortBy = currentSortByVe;
+        }
+        else {
+            veSortBy = getValueExpression(PropertyKeys.sortBy.name());
+        }
         if (veSortBy != null) {
             Collections.sort(filteredList, new BeanPropertyComparator(veSortBy, var, convertSortOrder(), null,
                         isCaseSensitiveSort(), Locale.ENGLISH, getNullSortOrder()));
@@ -611,7 +647,7 @@ public class Sheet extends SheetBase {
     /**
      * Gets the row key value as a String suitable for use in javascript rendering.
      *
-     * @param context
+     * @param key
      * @return
      */
     protected String getRowKeyValueAsString(final Object key) {

--- a/src/main/java/org/primefaces/extensions/component/sheet/SheetBase.java
+++ b/src/main/java/org/primefaces/extensions/component/sheet/SheetBase.java
@@ -214,9 +214,10 @@ abstract class SheetBase extends UIInput implements ClientBehaviorHolder, Widget
         caseSensitiveSort,
 
         /**
-         * The original sortBy value expression saved off for reset
+         * The ID of the current column to be used for sorting. This is used only internally
+         * and not exposed to the consumer of the sheet component.
          */
-        origSortBy,
+        currentSortBy,
 
         /**
          * The original sort direction saved off for reset
@@ -338,6 +339,20 @@ abstract class SheetBase extends UIInput implements ClientBehaviorHolder, Widget
             return null;
         }
         return result.toString();
+    }
+
+    /**
+     * Please note: The return type needs to be {@link Object}. Otherwise,
+     * evaluating the {@code sortBy} attribute as a value expression forces
+     * it into a string, and strings are sorted differently than numbers.
+     * @return The ID of the column to sort by.
+     */
+    public Object getSortBy() {
+        return getStateHelper().get(PropertyKeys.sortBy.name());
+    }
+
+    public void setSortBy(Object sortBy) {
+        getStateHelper().put(PropertyKeys.sortBy.name(), sortBy);
     }
 
     public void setShowColumnHeaders(final Boolean value) {
@@ -710,7 +725,7 @@ abstract class SheetBase extends UIInput implements ClientBehaviorHolder, Widget
     /**
      * Updates the height
      *
-     * @param row
+     * @param value
      */
     public void setHeight(final Integer value) {
         getStateHelper().put(PropertyKeys.height, value);
@@ -820,30 +835,11 @@ abstract class SheetBase extends UIInput implements ClientBehaviorHolder, Widget
     }
 
     /**
-     * The current sortBy value expression in use.
-     *
-     * @return
+     * Saves the column by which the sheet is currently sorted (when the user clicks on a column).
+     * @param columnId ID of the column by which the sheet is currently sorted.
      */
-    public ValueExpression getSortByValueExpression() {
-        final ValueExpression veSortBy = getValueExpression(PropertyKeys.sortBy.name());
-        return veSortBy;
-    }
-
-    /**
-     * Update the sort field
-     *
-     * @param sortBy
-     */
-    public void setSortByValueExpression(final ValueExpression sortBy) {
-        // when updating, make sure we store off the original so it may be
-        // restored
-        // ValueExpression orig = (ValueExpression)
-        // getStateHelper().get(PropertyKeys.origSortBy);
-        // if (orig == null) {
-        // getStateHelper().put(PropertyKeys.origSortBy,
-        // getSortByValueExpression());
-        // }
-        setValueExpression(PropertyKeys.sortBy.name(), sortBy);
+    public void saveSortByColumn(String columnId) {
+        getStateHelper().put(PropertyKeys.currentSortBy.name(), columnId);
     }
 
     /**

--- a/src/main/java/org/primefaces/extensions/component/sheet/SheetRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/sheet/SheetRenderer.java
@@ -846,7 +846,7 @@ public class SheetRenderer extends CoreRenderer {
             int col = Integer.valueOf(sortBy);
             if (col >= 0) {
                 col = sheet.getMappedColumn(col);
-                sheet.setSortByValueExpression(sheet.getColumns().get(col).getValueExpression("sortBy"));
+                sheet.saveSortByColumn(sheet.getColumns().get(col).getId());
             }
         }
 

--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -5471,7 +5471,7 @@
         </attribute>
         <attribute>
             <description>
-				<![CDATA[How the sheet rows should be sorted initially. If it is an expression, it must evaluate to the property to be used for sorting - this will not work when columns are specified dynamically. Otherwise, it can also be the ID of a sheet column by which the sheet rows should be sorted. In this case, you also need to set the sortBy attribute on the sheet column.]]>
+				<![CDATA[How the sheet rows should be sorted initially. If it is an expression, it must evaluate to the property to be used for sorting - this will not work when columns are specified dynamically. Otherwise, it can also be the ID (without any naming containers prefixed, ie. no parent elements with colons) of a sheet column by which the sheet rows should be sorted. In this case, you also need to set the sortBy attribute on the sheet column.]]>
             </description>
             <name>sortBy</name>
             <required>false</required>

--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -5471,7 +5471,7 @@
         </attribute>
         <attribute>
             <description>
-				<![CDATA[Property to be used for sorting.]]>
+				<![CDATA[How the sheet rows should be sorted initially. If it is an expression, it must evaluate to the property to be used for sorting - this will not work when columns are specified dynamically. Otherwise, it can also be the ID of a sheet column by which the sheet rows should be sorted. In this case, you also need to set the sortBy attribute on the sheet column.]]>
             </description>
             <name>sortBy</name>
             <required>false</required>


### PR DESCRIPTION
# Changes 

This should fix issue #713. I made the following changes:

* I added some clarification to the tag documentation for the `sortBy` attribute of the sheet. It specifies the property by which the sheet should be sorted initially. 
* `origSortBy` used to store the original value expression for resetting the sort. The part of the code where this is set was commented out, so it does not seem to have had any effect. I changed it `currentSortBy`, which now saves the ID of the column by which the sheet is currently sorted. The attribute `sortBy` is never modified, so there is no need to reset it.
* I also tested this commit with `movableCols` set to `true`. When the sheet is sorted by say the 3rd column, and the user moves the 2nd column to the right, the 3rd column is not at index 2. The sheet still shows the 3rd column as the sorted column. But this does not work in the current version of PF extensions either, so this is a different isues/ticket.
* When resetting the sheet, `currentSortBy` is simply reset to `null`. As mentioned above, storing the old value `origSortBy` was commented out. Was this intentional? I think this would remove any sorting when the sheet is reset. In case that was intentional, you should add the following line to `Sheet#resetSort` to remove any sorting on reset:

```java
getStateHelper().put(PropertyKeys.sortBy.name(), null);
```

To determine by which column to sort, I changed the code as follows:

1. Check if a valid column ID was stored in `currentSortBy`. If so, sort by that.
1. Otherwise, check if the `sortBy` expression evaluates to a valid ID of a column. If so, sort by that.
1. Otherwise, check if the literal value expression stored in the `sortBy` attribute matches the value expression of a sheet column. If so, use that.
1. Otherwise, if the `sortBy` attribute of the sheet is a value expression, sort the sheet data by that property (even when no column specifies a `sortBy` attribute)

The last two cases are there to ensure compatibility with xhtml code for previous versions. In case you do not require this compatibility, the code could be simplified a bit.

I think this is easier to understand by giving a few examples of how it works now.

This still works:

```xml
<pe:sheet id="sheet" value="#{sheetController.assets}" var="row" 
    sortBy="#{row.assetId}" sortOrder="ascending" >
    <pe:sheetcolumn sortBy="#{row.assetId}"  />
    <pe:sheetcolumn sortBy="#{row.assetType}"  />
</pe:sheet>
```

but you can now also write:

```xml
<pe:sheet id="sheet" value="#{sheetController.assets}" var="row" 
    sortBy="assertId" sortOrder="ascending" >
    <pe:sheetcolumn id="assetId" sortBy="#{row.assetId}"  />
    <pe:sheetcolumn id="assetType" sortBy="#{row.assetType}"  />
</pe:sheet>
```

The latter way is the only way to make it work for dynamic columns (sort by the 3rd column initially):

```xml
<pe:sheet id="sheet" value="#{sheetDynamicController.sheetRows}" var="row"
    sortBy="col2" sortOrder="ascending">
    <c:forEach items="#{sheetDynamicController.hoursOfDay}" var="hourOfDay" 
        varStatus="status">
        <pe:sheetcolumn id="col#{status.index}" sortBy="#{row.cells[status.index].value}" />
    /c:forEach>
</pe:sheet>
```

And in the above example, the user can also click on any column and it sorts by that column, which fixes issue #713:

![image](https://user-images.githubusercontent.com/2456413/61959805-7c937480-afc4-11e9-94e8-da280cbf39dc.png)

Finally, you can also omit the `sortBy` attribute on sheet column and only specify `sortBy` on the sheet, which just performs some initial sorting of the data:

```xml
<pe:sheet id="sheet" value="#{sheetAjaxController.assets}"
    sortBy="#{row.assetId}" sortOrder="ascending">
	<pe:sheetcolumn headerText="Id (readOnly)" value="#{row.assetId}" />
	<pe:sheetcolumn headerText="Type (readOnly)" value="#{row.assetType}" />
	<pe:sheetcolumn headerText="Platform (readOnly)" value="#{row.platform}" />
	<pe:sheetcolumn headerText="Arch (readOnly)" value="#{row.platformArch}" />
	<pe:sheetcolumn headerText="Editable" value="#{row.value1}" colType="numeric"/>
</pe:sheet>
```
