### PR TITLE
Fix #735, keep scroll position of CKEditor and CKMirror

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces-extensions/codemirror/widget.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/codemirror/widget.js
@@ -50,15 +50,16 @@ PrimeFaces.widget.ExtCodeMirror = PrimeFaces.widget.DeferredWidget.extend({
             $this.fireEvent('change');
         });
 
-        // Restore saved scroll position, if any
+        // Restore saved scroll position after an AJAX update, if any
         if (typeof this.scrollInfo === "object") {
             this.instance.scrollTo(this.scrollInfo.left, this.scrollInfo.top);
         }
 
-        // Save scroll position before AJAX update
-        this.addRefreshListener(function() {
-            if (this.instance) {
-                this.scrollInfo = this.instance.getScrollInfo();
+        // Save scroll position so we can restore it after an AJAX update
+        // Remember to do this after restoring the scroll position.
+        this.instance.on("scroll", function(cMirror) {
+            if (cMirror) {
+                $this.scrollInfo = cMirror.getScrollInfo();
             }
         });
     },


### PR DESCRIPTION
This solves primefaces-extensions/primefaces-extensions.github.com#735. CodeMirror was easy, but CKEditor is pretty complex. I added checks for the various properties of CKEditor to make sure we don't get any JavaScript errors when some of its elements are `undefined`.

* The `refresh` hook of the widgets is (sometimes) only called after the previous element was removed. So instead, we register a listener on the `scroll` event and save the current scroll position.
* Then, when the CKEditor or CodeMirror is updated via AJAX, we can restore the scroll position.
* CKEditor has got two modes, `source` and `WYSIWYG`. Depending on the mode, the scroll listener needs to be registered differently. When the editor was in source mode before an AJAX update, we also set it back to source mode after the update. Also, care needs to be taken to avoid registering a listener twice.