### PR TITLE
Fix 723 Cleaned up TimePicker styling

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/timepicker/TimePicker.java
+++ b/src/main/java/org/primefaces/extensions/component/timepicker/TimePicker.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import javax.faces.application.ResourceDependencies;
 import javax.faces.application.ResourceDependency;
 import javax.faces.component.html.HtmlInputText;
@@ -31,7 +30,6 @@ import javax.faces.context.FacesContext;
 import javax.faces.event.AjaxBehaviorEvent;
 import javax.faces.event.FacesEvent;
 import javax.faces.event.PhaseId;
-
 import org.primefaces.component.api.Widget;
 import org.primefaces.extensions.event.BeforeShowEvent;
 import org.primefaces.extensions.event.CloseEvent;
@@ -59,10 +57,9 @@ import org.primefaces.util.LocaleUtils;
 public class TimePicker extends HtmlInputText implements Widget {
 
     public static final String CONTAINER_CLASS = "pe-timepicker ui-widget ui-corner-all";
-    public static final String INPUT_CLASS = "ui-inputfield pe-timepicker-input ui-state-default ui-corner-all";
-    public static final String UP_BUTTON_CLASS = "pe-timepicker-button pe-timepicker-up ui-corner-tr ui-button ui-widget ui-state-default ui-button-text-only";
-    public static final String DOWN_BUTTON_CLASS = "pe-timepicker-button pe-timepicker-down ui-corner-br ui-button ui-widget ui-state-default "
-                + "ui-button-text-only";
+    public static final String INPUT_CLASS = "ui-inputfield ui-state-default ui-corner-all";
+    public static final String UP_BUTTON_CLASS = "ui-spinner-button ui-spinner-up ui-corner-tr ui-button ui-widget ui-state-default";
+    public static final String DOWN_BUTTON_CLASS = "ui-spinner-button ui-spinner-down ui-corner-br ui-button ui-widget ui-state-default";
     public static final String UP_ICON_CLASS = "ui-icon ui-icon-triangle-1-n";
     public static final String DOWN_ICON_CLASS = "ui-icon ui-icon-triangle-1-s";
     public static final String BUTTON_TRIGGER_CLASS = "pe-timepicker-trigger ui-button ui-widget ui-state-default ui-corner-all ui-button-icon-only";
@@ -358,6 +355,10 @@ public class TimePicker extends HtmlInputText implements Widget {
 
     public boolean isSpinner() {
         return getMode().equalsIgnoreCase("spinner");
+    }
+
+    public boolean isShowOnButton() {
+        return !"focus".equals(getShowOn());
     }
 
     @Override

--- a/src/main/java/org/primefaces/extensions/component/timepicker/TimePicker.java
+++ b/src/main/java/org/primefaces/extensions/component/timepicker/TimePicker.java
@@ -107,7 +107,8 @@ public class TimePicker extends HtmlInputText implements Widget {
         minMinute,
         maxHour,
         maxMinute,
-        readonlyInput;
+        readonlyInput,
+        size;
         //@formatter:on
 
         private String toString;
@@ -340,6 +341,16 @@ public class TimePicker extends HtmlInputText implements Widget {
 
     public void setReadonlyInput(final boolean _readonlyInput) {
         getStateHelper().put(PropertyKeys.readonlyInput, _readonlyInput);
+    }
+
+    @Override
+    public int getSize() {
+        return (Integer) getStateHelper().eval(PropertyKeys.size, 5);
+    }
+
+    @Override
+    public void setSize(final int size) {
+        getStateHelper().put(PropertyKeys.size, size);
     }
 
     public Locale calculateLocale() {

--- a/src/main/java/org/primefaces/extensions/component/timepicker/TimePickerRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/timepicker/TimePickerRenderer.java
@@ -75,7 +75,15 @@ public class TimePickerRenderer extends InputRenderer {
 
         writer.startElement("span", timepicker);
         writer.writeAttribute("id", clientId, null);
-        writer.writeAttribute("class", TimePicker.CONTAINER_CLASS, null);
+
+        String containerClass = TimePicker.CONTAINER_CLASS;
+        if (timepicker.isSpinner()) {
+            containerClass += " ui-spinner";
+        }
+        if (timepicker.isShowOnButton()) {
+            containerClass += " ui-inputgroup";
+        }
+        writer.writeAttribute("class", containerClass, null);
 
         if (timepicker.isInline()) {
             // inline container
@@ -101,8 +109,11 @@ public class TimePickerRenderer extends InputRenderer {
         if (!timepicker.isInline()) {
             String styleClass = timepicker.getStyleClass();
             styleClass = styleClass == null ? TimePicker.INPUT_CLASS : TimePicker.INPUT_CLASS + " " + styleClass;
+            if (timepicker.isShowOnButton()) {
+                styleClass += " ui-inputtext";
+            }
             if (!timepicker.isValid()) {
-                styleClass = styleClass + " ui-state-error";
+                styleClass += " ui-state-error";
             }
 
             writer.writeAttribute("class", styleClass, null);
@@ -125,7 +136,7 @@ public class TimePickerRenderer extends InputRenderer {
             encodeSpinnerButton(fc, TimePicker.DOWN_BUTTON_CLASS, TimePicker.DOWN_ICON_CLASS, disabled);
         }
 
-        if (!"focus".equals(timepicker.getShowOn())) {
+        if (timepicker.isShowOnButton()) {
             writer.startElement("button", null);
             writer.writeAttribute("class", TimePicker.BUTTON_TRIGGER_CLASS, null);
             writer.writeAttribute("type", "button", null);
@@ -177,7 +188,7 @@ public class TimePickerRenderer extends InputRenderer {
             wb.nativeAttr("onMinuteShow", timepicker.getOnMinuteShow());
         }
 
-        if (!"focus".equals(timepicker.getShowOn())) {
+        if (timepicker.isShowOnButton()) {
             wb.attr("showOn", timepicker.getShowOn());
             wb.selectorAttr("button", "#" + clientId + " .pe-timepicker-trigger");
         }

--- a/src/main/java/org/primefaces/extensions/component/timepicker/TimePickerRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/timepicker/TimePickerRenderer.java
@@ -96,7 +96,9 @@ public class TimePickerRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, null);
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", timepicker.isInline() ? "hidden" : "text", null);
-        writer.writeAttribute("size", timepicker.getSize(), null);
+        if (timepicker.getSize() > 0) {
+            writer.writeAttribute("size", timepicker.getSize(), null);
+        }
         writer.writeAttribute("autocomplete", "off", null);
 
         if (timepicker.isReadonlyInput()) {

--- a/src/main/java/org/primefaces/extensions/component/timepicker/TimePickerRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/timepicker/TimePickerRenderer.java
@@ -96,6 +96,7 @@ public class TimePickerRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, null);
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", timepicker.isInline() ? "hidden" : "text", null);
+        writer.writeAttribute("size", timepicker.getSize(), null);
         writer.writeAttribute("autocomplete", "off", null);
 
         if (timepicker.isReadonlyInput()) {
@@ -109,6 +110,9 @@ public class TimePickerRenderer extends InputRenderer {
         if (!timepicker.isInline()) {
             String styleClass = timepicker.getStyleClass();
             styleClass = styleClass == null ? TimePicker.INPUT_CLASS : TimePicker.INPUT_CLASS + " " + styleClass;
+            if (timepicker.isSpinner()) {
+                styleClass += " ui-spinner-input";
+            }
             if (timepicker.isShowOnButton()) {
                 styleClass += " ui-inputtext";
             }

--- a/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -3630,6 +3630,14 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Number of characters used to determine the width of the input element. Default is 5.]]>
+            </description>
+            <name>size</name>
+            <required>false</required>
+            <type>int</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/1-timepicker.css
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/1-timepicker.css
@@ -1,27 +1,30 @@
-.pe-timepicker .ui-inputfield {
+.pe-timepicker, body .pe-timepicker.ui-spinner {
+    display: inline-flex;
+}
+
+body .pe-timepicker .ui-inputfield {
     text-align: left;
-    width: 4rem;
+    box-sizing: border-box;
 }
 
 .pe-timepicker-trigger .ui-icon-clock {
     left: 50%;
 }
 
-.pe-timepicker-trigger {
-    width: 1.9rem;
-    height: 1.8rem;
-}
-
-.pe-timepicker.ui-spinner.ui-inputgroup {
-    display: flex;
+body .ui-button-icon-only.pe-timepicker-trigger {
+    flex: 0 0 28px;
 }
 
 .pe-timepicker.ui-spinner.ui-inputgroup .ui-spinner-button {
-    right: 1.9rem;
+    right: 29px;
+}
+
+.ui-timepicker {
+    z-index: 999;
 }
 
 .ui-timepicker-table {
-    background-color: #ffffff;
+    background-color: #fff;
     border: 1px solid #a6a6a6;
     padding: 0.857em;
 }
@@ -31,7 +34,7 @@
 }
 
 body .ui-timepicker-table td a {
-    color: #333333;
+    color: #333;
     padding: 0.286em;
 }
 

--- a/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/1-timepicker.css
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/1-timepicker.css
@@ -1,63 +1,38 @@
-.pe-timepicker {
-    display: inline-block;
-    overflow: visible;
-    padding: 0;
-    position: relative;
-    vertical-align: middle;
-}
-
-.pe-timepicker-input {
-    vertical-align: middle;
+.pe-timepicker .ui-inputfield {
     text-align: left;
-    width: 60px;
-}
-
-.pe-timepicker-button {
-    cursor: default;
-    display: block;
-    font-size: 0.5em;
-    height: 44%;
-    margin: 0;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    right: 0;
-    text-align: center;
-    vertical-align: middle;
-    width: 16px;
-    z-index: 100;
-}
-
-.pe-timepicker .ui-icon {
-    left: 0;
-    margin-top: -8px;
-    position: absolute;
-    top: 50%;
-}
-
-.pe-timepicker-button.pe-timepicker-up {
-    top: 0;
-    border-bottom: none;
-}
-
-.pe-timepicker-button.pe-timepicker-down {
-    bottom: 0;
-}
-
-.pe-timepicker .ui-icon-triangle-1-s {
-    background-position: -65px -16px;
-}
-
-.pe-timepicker-trigger {
-    position: absolute;
-    margin: 1px 0 1px 1px;
-    height: 2em;
-    width: 2em;
-    vertical-align: middle;
+    width: 4rem;
 }
 
 .pe-timepicker-trigger .ui-icon-clock {
     left: 50%;
+}
+
+.pe-timepicker-trigger {
+    width: 1.9rem;
+    height: 1.8rem;
+}
+
+.pe-timepicker.ui-spinner.ui-inputgroup {
+    display: flex;
+}
+
+.pe-timepicker.ui-spinner.ui-inputgroup .ui-spinner-button {
+    right: 1.9rem;
+}
+
+.ui-timepicker-table {
+    background-color: #ffffff;
+    border: 1px solid #a6a6a6;
+    padding: 0.857em;
+}
+
+.ui-timepicker-table td {
+    padding: 0.286em;
+}
+
+body .ui-timepicker-table td a {
+    color: #333333;
+    padding: 0.286em;
 }
 
 body .ui-prime-icons .ui-icon {
@@ -71,11 +46,6 @@ body .ui-prime-icons .ui-icon {
     display: inline-block;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    text-indent: 0px !important;
-    text-align: center;
-    background: none;
-    display: inline-block;
-    font-size: 1.25em;
 }
 
 body .ui-prime-icons .ui-icon-clock:before {

--- a/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/1-timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/1-timepicker.js
@@ -142,20 +142,20 @@ PrimeFaces.widget.ExtTimePicker = PrimeFaces.widget.BaseWidget.extend({
         $(this.jqId + '_input').data(PrimeFaces.CLIENT_ID_DATA, this.id);
 
         this.removeScriptElement(this.id);
-        
+
         this.originalValue = this.jq.val();
 	},
-	
+
 	enableInput : function() {
 	    var _self = this;
-	    
+
 	    PrimeFaces.skinInput(this.jq);
-	    
+
 	    this.jq.on({
 	        keydown: function(e){
 	            var keyCode = $.ui.keyCode;
-	            
-	            switch(e.which) {            
+
+	            switch(e.which) {
 	                case keyCode.UP:
 	                    _self.spin(1);
 	                break;
@@ -178,7 +178,7 @@ PrimeFaces.widget.ExtTimePicker = PrimeFaces.widget.BaseWidget.extend({
 	                    _self.spin(1);
 	                else
 	                    _self.spin(-1);
-	                
+
 	                clearInterval(_self.spinnerInterval);
 	                return false;
 	            }
@@ -189,7 +189,7 @@ PrimeFaces.widget.ExtTimePicker = PrimeFaces.widget.BaseWidget.extend({
 	enableSpinner : function() {
 	    var _self = this;
 
-	    $(this.jqId).children('.pe-timepicker-button')
+	    $(this.jqId).children('.ui-spinner-button')
                 .removeClass('ui-state-disabled')
                 .off('mouseover mouseout mouseup mousedown')
                 .on({
@@ -198,19 +198,19 @@ PrimeFaces.widget.ExtTimePicker = PrimeFaces.widget.BaseWidget.extend({
                     },
                     mouseout: function(){
                         $(this).removeClass('ui-state-hover');
-                        
+
                         clearInterval(_self.spinnerInterval);
                     },
                     mouseup: function(){
                         $(this).removeClass('ui-state-active');
-                        
+
                         clearInterval(_self.spinnerInterval);
                     },
                     mousedown: function(e){
                         var el = $(this);
                         el.addClass('ui-state-active');
 
-                        var dir = el.hasClass('pe-timepicker-up') ? 1 : -1;
+                        var dir = el.hasClass('ui-spinner-up') ? 1 : -1;
                         _self.spin(dir);
 
                         _self.spinnerInterval = setInterval(function() {
@@ -223,7 +223,7 @@ PrimeFaces.widget.ExtTimePicker = PrimeFaces.widget.BaseWidget.extend({
 	},
 
 	disableSpinner : function() {
-	    $(this.jqId).children('.pe-timepicker-button').
+	    $(this.jqId).children('.ui-spinner-button').
 	    removeClass('ui-state-hover ui-state-active').
 	    addClass('ui-state-disabled').
 	    off('mouseover mouseout mouseup mousedown');
@@ -532,7 +532,7 @@ PrimeFaces.widget.ExtTimePicker = PrimeFaces.widget.BaseWidget.extend({
 	        this.enableSpinner();
         }
 	},
-    
+
     reset : function(cfg) {
         this.jq.val(this.originalValue);
     }


### PR DESCRIPTION
This should fix https://github.com/primefaces-extensions/primefaces-extensions.github.com/issues/723

It's looking good on my MacBook with Chrome. We might want to test with some other browsers. I think we are alright though, since the majority of the styling is inherited from existing components (like spinner and input group)