### PR TITLE
Fixed countries string to list

### DIFF
--- a/src/main/java/org/primefaces/extensions/component/inputphone/InputPhoneRenderer.java
+++ b/src/main/java/org/primefaces/extensions/component/inputphone/InputPhoneRenderer.java
@@ -247,7 +247,7 @@ public class InputPhoneRenderer extends InputRenderer {
 
     private Collection<String> toCollection(Object object) {
         if (String.class.isInstance(object)) {
-            final String string = ((String) object).replaceAll(" ", Constants.EMPTY_STRING).toLowerCase();
+            final String string = ((String) object).replaceAll(" ", ",").toLowerCase();
             return Arrays.asList(string.split(","));
         }
         return (Collection<String>) object;


### PR DESCRIPTION
@melloware I think this was a bug. It should have been converting `"nl be de"` to `["nl", "be", "de"]` (it should support both comma and space separated). I did this using the online editor in Git, but I think I need to give this a second look.