### PR TITLE
CodeMirror: #220 Do not HTML escape suggestions

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/codemirror/widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/codemirror/widget.js
@@ -160,7 +160,7 @@ PrimeFaces.widget.ExtCodeMirror = PrimeFaces.widget.DeferredWidget.extend({
                         }).children();
 
                         parsedSuggestions.each(function() {
-                            $this.suggestions.push($(this).html());
+                            $this.suggestions.push($(this).text());
                         });
 
                         CodeMirror.showHint($this.instance, PrimeFaces.widget.ExtCodeMirror.getSuggestions);


### PR DESCRIPTION
I was using pe:codeMirror with the autocomplete feature via a bean method. The bean method returned several suggestions, including `&&`.

The problem was that this got displayed as `&amp;&amp;` in the hint overlay from CodeMirror.

The suggestions are send back to the client correctly, but when building the suggestions array, the PrimeFaces extensions CodeMirror widget uses `jQuery.html` instead of `jQuery.text`. This returns the text escaped for HTML. This suggestions array is then passed on as the `list` option of the [show hint addon](https://codemirror.net/doc/manual.html#addon_show-hint). This option expects an array of strings. The show hint addon seems to be handling HTML escaping properly, so we should not be doing it. Perhaps it was different in a previous version of CodeMirror?
