### PR TITLE
Fix #279 TimePicker: headings are incorrectly styled in popup with dark theme

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/0-jquery.ui.timepicker.css
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/0-jquery.ui.timepicker.css
@@ -21,7 +21,7 @@
 .ui-timepicker-table th.periods { padding: 0.1em; width: 2.2em; }
 
 /* span for disabled cells */
-.ui-timepicker-table td span {
+.ui-timepicker-table td > span {
 	display:block;
     padding:0.2em 0.3em 0.2em 0.5em;
     width: 1.2em;
@@ -44,7 +44,6 @@
 .ui-timepicker .ui-timepicker-buttonpane {
     background-image: none; margin: .7em 0 0 0; padding:0 .2em; border-left: 0; border-right: 0; border-bottom: 0;
 }
-.ui-timepicker .ui-timepicker-buttonpane button { margin: .5em .2em .4em; cursor: pointer; padding: .2em .6em .3em .6em; width:auto; overflow:visible; }
 /* The close button */
 .ui-timepicker .ui-timepicker-close { float: right }
 

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/0-jquery.ui.timepicker.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/0-jquery.ui.timepicker.js
@@ -656,20 +656,22 @@
 
             if (showButtonPanel) {
                 var buttonPanel = '<tr><td colspan="3"><div class="ui-timepicker-buttonpane ui-widget-content">';
+                var btnClasses = 'ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only';
+                var btnSpan = '<span class="ui-button-text">'
                 if (showNowButton) {
-                    buttonPanel += '<button type="button" class="ui-timepicker-now ui-state-default ui-corner-all" '
+                    buttonPanel += '<button type="button" class="ui-timepicker-now ' + btnClasses + '" '
                         + ' data-timepicker-instance-id="#' + inst.id.replace(/\\\\/g, "\\") + '" >'
-                        + nowButtonText + '</button>';
+                        + btnSpan + nowButtonText + '</span></button>';
                 }
                 if (showDeselectButton) {
-                    buttonPanel += '<button type="button" class="ui-timepicker-deselect ui-state-default ui-corner-all" '
+                    buttonPanel += '<button type="button" class="ui-timepicker-deselect ' + btnClasses + '" '
                         + ' data-timepicker-instance-id="#' + inst.id.replace(/\\\\/g, "\\") + '" >'
-                        + deselectButtonText + '</button>';
+                        + btnSpan + deselectButtonText + '</span></button>';
                 }
                 if (showCloseButton) {
-                    buttonPanel += '<button type="button" class="ui-timepicker-close ui-state-default ui-corner-all" '
+                    buttonPanel += '<button type="button" class="ui-timepicker-close ' + btnClasses + '" '
                         + ' data-timepicker-instance-id="#' + inst.id.replace(/\\\\/g, "\\") + '" >'
-                        + closeButtonText + '</button>';
+                        + btnSpan + closeButtonText + '</span></button>';
                 }
 
                 html += buttonPanel + '</div></td></tr>';

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/1-timepicker.css
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/timepicker/1-timepicker.css
@@ -25,12 +25,16 @@ body .ui-timepicker {
 
 body .ui-timepicker-table {
     background-color: var(--surface-f, #fff);
-    border: 1px solid var(--surface-d, #ced4da);
-    padding: 0.857em;
+    border-collapse: collapse;
+    outline: 1px solid var(--surface-d, #ced4da);
+}
+
+body .ui-timepicker-table > tbody {
+  border: .5rem solid var(--surface-f, #fff);
 }
 
 body .ui-timepicker-table td {
-    padding: 0.5rem;
+    padding: .5rem;
 }
 
 body .ui-timepicker .ui-timepicker-table td a {
@@ -55,14 +59,22 @@ body .ui-timepicker .ui-timepicker-table td a.ui-state-default.ui-state-active {
 
 body .ui-timepicker .ui-timepicker-title {
     padding: 0 1em;
+    color: var(--text-color, #333);
     background-color: var(--surface-a, #fff);
 }
 
+body .ui-timepicker td.ui-timepicker-hours,
 body .ui-timepicker td.ui-timepicker-minutes {
-    padding-left: 4px;
-    padding-right: 4px;
-    padding-bottom: 4px;
+    vertical-align: top;
+    padding: .5rem;
+}
+
+body .ui-timepicker td.ui-timepicker-minutes {
     border-left: 1px solid var(--surface-d, #3373a0);
+}
+
+.ui-timepicker-table th.periods {
+    color: var(--text-color, #333);
 }
 
 body .ui-prime-icons .ui-icon {


### PR DESCRIPTION
Fix #279

<img width="519" alt="Screen Shot 2021-01-24 at 15 49 13" src="https://user-images.githubusercontent.com/7500178/105633984-017e7900-5e5c-11eb-94fd-8b70aad28530.png">

<img width="475" alt="Screen Shot 2021-01-24 at 15 49 22" src="https://user-images.githubusercontent.com/7500178/105633992-080cf080-5e5c-11eb-90bd-b161909fd353.png">
