### PR TITLE
Fix 338: Core: JS changeTheme does not work with combined resource handler

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/core/core.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/core/core.js
@@ -4,16 +4,17 @@
 PrimeFacesExt = {
 
     /**
-     * Change the theme and if using OmniFaces CombinedResourceHandler we need to create the URL and insert it
-     * since it will not exist.
-     * @param theme the theme to switch to
+     * Change the theme and if using OmniFaces CombinedResourceHandler we need to create the DOM node
+     * and append it to the body since it will not exist. Appending to the body will make sure that the
+     * theme that's switched to will be loaded last and thereby override existing rules.
+     * @param {string} theme the theme to switch to.
      */
     changeTheme: function (theme) {
         var themeLink = PrimeFaces.getThemeLink();
         if (!themeLink || themeLink.length === 0) {
             var ext = PrimeFacesExt.getResourceUrlExtension();
             var href = PrimeFaces.settings.contextPath + '/javax.faces.resource/theme.css.' + ext + '?ln=primefaces-' + theme + '&' + PrimeFacesExt.VERSION;
-            $('head').append('<link rel="stylesheet" type="text/css" href="' + href + '" />');
+            $('body').append('<link rel="stylesheet" type="text/css" href="' + href + '" />');
         } else {
             PrimeFaces.changeTheme(theme);
         }
@@ -38,8 +39,7 @@ PrimeFacesExt = {
     /**
      * For a URI parses out the name of the script like primefaces-extensions.js
      *
-     * @param the
-     *        URI of the script
+     * @param {string} the URI of the script.
      * @returns {string} The script name.
      */
     getResourceScriptName: function (scriptURI) {

--- a/showcase/src/main/webapp/views/lightSwitch.xhtml
+++ b/showcase/src/main/webapp/views/lightSwitch.xhtml
@@ -8,28 +8,25 @@
             <h:outputText value="LightSwitch"/>
         </f:facet>
         <h:panelGroup layout="block" styleClass="centerContent">
-            <p>
-            Automatically sets a light or dark theme based on the OS settings. Put it in your template like:
-            </p>
+            <p>Automatically sets a light or dark theme based on the OS settings. Put it in your template like:</p>
             <pre>
 &lt;pe:lightSwitch selected="\#{userBean.theme}"/&gt;
             </pre>
-            <p>
-            <code>userBean</code> should be a session scoped bean with a <code>String</code> type theme property
-            (with both getter and setter). Then set the theme in your <code>web.xml</code> like:
-            </p>
+            <p><code>userBean</code> should be a session scoped bean with a <code>String</code> type theme property
+            (with both getter and setter). Then set the theme in your <code>web.xml</code> like:</p>
             <pre>
 &lt;context-param&gt;
     &lt;param-name&gt;primefaces.THEME&lt;/param-name&gt;
     &lt;param-value&gt;\#{userBean.theme}&lt;/param-value&gt;
 &lt;/context-param&gt;
             </pre>
-            <p>
-            This showcase <a href="https://github.com/primefaces-extensions/primefaces-extensions/blob/master/showcase/src/main/webapp/templates/masterLayout.xhtml">uses the LightSwitch component</a>.
-            </p>
-            <p>
-            See also the <a href="https://primefaces.github.io/primefaces/10_0_0/#/core/themes">PrimeFaces themes documentation</a>.
-            </p>
+            <p>This showcase <a href="https://github.com/primefaces-extensions/primefaces-extensions/blob/master/showcase/src/main/webapp/templates/masterLayout.xhtml">uses the LightSwitch component</a>.</p>
+            <p>See also the <a href="https://primefaces.github.io/primefaces/10_0_0/#/core/themes">PrimeFaces themes documentation</a>.</p>
+
+            <h3><a href="https://showcase.omnifaces.org/resourcehandlers/CombinedResourceHandler">OmniFaces <code>CombinedResourceHandler</code></a></h3>
+            <p>With combined resources, we cannot find the theme link in the DOM tree. Therefor we need to add a node for the new theme.<br/>
+                <strong>Important:</strong> this node will be added as the last element in the body. If you added a custom style sheet with overrides,
+                make sure to use more specific rules. Equal rules will be overruled by the switched theme.</p>
         </h:panelGroup>
     </ui:define>
     <ui:define name="useCases">


### PR DESCRIPTION
Fix #338

You can test this in production. Cut the DOM node that `changeTheme` added to the `head` and paste it to the `body`.