### PR TITLE
[MonacoEditor] fix #372, do not render monaco editor twice

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/02-monaco-promise-queue.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/02-monaco-promise-queue.js
@@ -15,9 +15,7 @@ window.monacoModule.PromiseQueue = (function () {
   class PromiseQueueImpl {
     constructor() {
       /** @type {QueueItem[]} */
-      this.queue = [];
-      /** @type {{resolve: PromiseCallback, reject: PromiseCallback}[]} */
-      this.onDone = [];
+      this._queue = [];
     }
 
     /**
@@ -47,8 +45,8 @@ window.monacoModule.PromiseQueue = (function () {
      * @param {PromiseCallback} reject
      */
     _addQueueItem(factory, resolve, reject) {
-      const wasEmpty = this.queue.length === 0;
-      this.queue.push({
+      const wasEmpty = this._queue.length === 0;
+      this._queue.push({
         factory: factory,
         resolve: resolve,
         reject: reject,
@@ -62,7 +60,7 @@ window.monacoModule.PromiseQueue = (function () {
       this._processQueue(this._peek());
     }
 
-    onPromiseDone() {
+    _onPromiseDone() {
       this._poll();
       this._processQueue(this._peek());
     }
@@ -76,11 +74,7 @@ window.monacoModule.PromiseQueue = (function () {
         promise
           .then(queueItem.resolve)
           .catch(queueItem.reject)
-          .then(() => this.onPromiseDone());
-      }
-      else {
-        this.onDone.forEach(({ resolve }) => resolve(undefined));
-        this.onDone = [];
+          .then(() => this._onPromiseDone());
       }
     }
 
@@ -88,28 +82,14 @@ window.monacoModule.PromiseQueue = (function () {
      * @return {QueueItem}
      */
     _poll() {
-      return this.queue.shift();
+      return this._queue.shift();
     }
 
     /**
      * @return {QueueItem}
      */
     _peek() {
-      return this.queue[0];
-    }
-
-    /**
-     * @return {Promise<void>}
-     */
-    _allDone() {
-      if (this.queue.length === 0) {
-        return Promise.resolve();
-      }
-      else {
-        return new Promise((resolve, reject) => {
-          this.onDone.push({ resolve, reject });
-        });
-      }
+      return this._queue[0];
     }
 
     /**

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/03-monaco-widget-base.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/03-monaco-widget-base.js
@@ -172,7 +172,7 @@ window.monacoModule.ExtMonacoEditorBase = (function () {
       const onDone = this._onDone;
       this._onDone = [];
       if (Array.isArray(onDone) && onDone.length > 0) {
-        const error = new Error("Monaco editor was reinitialized before whenReady could be resolved");
+        const error = new Error("Monaco editor was destroyed / refreshed before whenReady could be resolved");
         for (const item of onDone) {
           item.reject(error);
         }
@@ -198,7 +198,12 @@ window.monacoModule.ExtMonacoEditorBase = (function () {
      * @param {unknown} error
      */
     _onInitError(error) {
-      console.error("[MonacoEditor] Failed to initialize monaco editor", error);
+      if (error === "render_canceled_by_update") {
+        error = new Error("Monaco editor was refreshed / destroyed before it could be rendered");
+      }
+      else {
+        console.error("[MonacoEditor] Failed to initialize monaco editor", error);
+      }
       for (const { reject } of this._onDone) {
         reject(error);
       }

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-widget-inline.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-widget-inline.js
@@ -202,6 +202,7 @@ PrimeFaces.widget.ExtMonacoEditorInline = (function () {
      */
     _onRefresh() {
       this._scrollTop = this.tryWithMonaco(monaco => monaco.getScrollTop(), 0);
+      PrimeFaces.removeDeferredRenders(this.id);
       this._onDestroy();
     }
 
@@ -210,6 +211,10 @@ PrimeFaces.widget.ExtMonacoEditorInline = (function () {
      * resize observer, if enabled.
      */
     _onDestroy() {
+      if (this._renderArgs) {
+        this._renderArgs.reject("render_canceled_by_update");
+        this._renderArgs = undefined;
+      }
       this._rejectOnDone();
       const extender = this._extenderInstance;
       if (extender && typeof extender.beforeDestroy === "function") {
@@ -301,7 +306,7 @@ PrimeFaces.widget.ExtMonacoEditorInline = (function () {
         this.tryWithMonaco(monaco => monaco.setScrollTop(this._scrollTop), undefined);
       }
 
-      // Auto resize
+      // Auto resize when browser supports ResizeObserver
       if (this.cfg.autoResize) {
         if (typeof ResizeObserver === "function") {
           this._resizeObserver = new ResizeObserver(this._onResize.bind(this));

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/primefaces-main.d.ts
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/primefaces-main.d.ts
@@ -10,6 +10,7 @@ declare namespace PrimeFaces {
   function info(message: string): void;
   function warn(message: string): void;
   function error(message: string): void;
+  function removeDeferredRenders(id: string): void;
   namespace resources {
     function getFacesResource(path: string, lib: string, version?: string): string;
     function getResourceUrlExtension(): string;


### PR DESCRIPTION
* Call PrimeFaces.removeDeferredRenders(this.id) on refresh so it does
  not invoke the deferred renderer multiple times.
* Reject the pending promise from the deferred renderer so that we do
  not keep unresolved promises around.
* Remove dead / unused internal code from promise queue.