### PR TITLE
Fix #383: Layout: white background is bleeding in dark themes 

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/layout/layout.css
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/layout/layout.css
@@ -3,8 +3,13 @@
     overflow: hidden;
 }
 
+body.ui-layout-container, body .ui-layout-container {
+    background-color: var(--surface-a, #fff);
+}
+
 body .ui-layout-container .ui-layout-unit {
     border: 1px solid var(--surface-d, #dee2e6);
+    background-color: var(--surface-a, #fff);
 }
 
 body .ui-layout-resizer {
@@ -101,11 +106,12 @@ body .ui-layout-resizer {
 body .ui-layout-unit {
     -moz-border-radius: 0;
     -webkit-border-radius: 0;
-    border-radius: 0
+    border-radius: 0;
+    background-color: var(--surface-a, #fff);
 }
 
 body .ui-layout-unit .ui-layout-unit-header {
     padding: .571em 1em .571em 1em;
-    font-weight: 700
+    font-weight: 700;
 }
 


### PR DESCRIPTION
Fix #383

<img width="1010" alt="Screenshot 2021-05-06 at 08 44 49" src="https://user-images.githubusercontent.com/7500178/117253502-90316780-ae47-11eb-9368-d954e1e4d0de.png">
