### PR TITLE
Fixes for monaco editor 0.31.0

### DIFF
--- a/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -488,7 +488,7 @@
         <attribute>
             <description>
                 <![CDATA[Locale for the user interface. Can be either a <code>java.util.Locale</code> object or a string with the locale code.
-                Built-in languages are "bg", "de", "en", "es", "fr", "hu", "it", "ja", "ko", "ps", "pt_BR", "ru", "tr", "uk", "zh_CN", and "zh_TW".
+                Built-in languages are "cs", "de", "en", "es", "fr", "it", "ja", "ko", "pl", "pt_BR", "ru", "tr", "zh_CN", and "zh_TW".
                 To use a custom language or translation, you can specify a language file with custom translations via the option
                 <code>localeUrl</code>.]]>
             </description>
@@ -888,7 +888,7 @@
         <attribute>
             <description>
                 <![CDATA[Locale for the user interface. Can be either a <code>java.util.Locale</code> object or a string with the locale code.
-                Built-in languages are "bg", "de", "en", "es", "fr", "hu", "it", "ja", "ko", "ps", "pt_BR", "ru", "tr", "uk", "zh_CN", and "zh_TW".
+                Built-in languages are "cs", "de", "en", "es", "fr", "it", "ja", "ko", "pl", "pt_BR", "ru", "tr", "zh_CN", and "zh_TW".
                 To use a custom language or translation, you can specify a language file with custom translations via the option
                 <code>localeUrl</code>.]]>
             </description>

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/01-monaco-helper.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/01-monaco-helper.js
@@ -7,12 +7,12 @@ window.monacoModule.helper = (function () {
   /** Map between the language label and the worker that should be used. */
   const workerMap = {
     css: "css.worker.js",
-    handlebars: "html.worker.js", 
+    handlebars: "html.worker.js",
     html: "html.worker.js",
     javascript: "ts.worker.js",
     json: "json.worker.js",
     less: "css.worker.js",
-    razor: "html.worker.js", 
+    razor: "html.worker.js",
     scss: "css.worker.js",
     typescript: "ts.worker.js",
   }
@@ -152,7 +152,7 @@ window.monacoModule.helper = (function () {
         return {
           forceLibReload: MonacoEnvironment.Locale.language !== options.locale,
           localeUrl: ""
-        };  
+        };
       }
     }
     else {
@@ -449,6 +449,14 @@ window.monacoModule.helper = (function () {
     localeUrl: "",
   };
 
+  /** @type {import("monaco-editor").editor.IStandaloneThemeData} */
+  const DefaultThemeData = {
+    base: "vs",
+    colors: {},
+    inherit: true,
+    rules: [],
+  };
+
 
   /** @type {PrimeFaces.widget.ExtMonacoEditorFramedCfgBase} */
   const FramedEditorDefaults = assign({}, BaseEditorDefaults, {
@@ -481,6 +489,7 @@ window.monacoModule.helper = (function () {
     loadLanguage,
     resolveLocaleUrl,
     BaseEditorDefaults,
+    DefaultThemeData,
     FramedEditorDefaults,
     InlineEditorDefaults,
   };

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-iframe-controller.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-iframe-controller.js
@@ -7,6 +7,7 @@ window.MonacoEnvironment.IframeContext = (function () {
   const {
     assign,
     createEditorConstructionOptions,
+    DefaultThemeData,
     FramedEditorDefaults,
     getScriptName,
     globalEval,
@@ -226,7 +227,7 @@ window.MonacoEnvironment.IframeContext = (function () {
 
       // Register all custom themes that we were given. 
       for (const themeName of Object.keys(this.cfg.customThemes || {})) {
-        const themeData = this.cfg.customThemes[themeName];
+        const themeData = assign({}, DefaultThemeData, this.cfg.customThemes[themeName]);
         if (themeData !== undefined) {
           monaco.editor.defineTheme(themeName, themeData);
         }

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-widget-inline.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-widget-inline.js
@@ -5,7 +5,9 @@ window.monacoModule = window.monacoModule || {};
 PrimeFaces.widget.ExtMonacoEditorInline = (function () {
 
   const {
+    assign,
     createEditorConstructionOptions,
+    DefaultThemeData,
     getMonacoResource,
     getScriptName,
     InlineEditorDefaults,
@@ -301,7 +303,7 @@ PrimeFaces.widget.ExtMonacoEditorInline = (function () {
 
       // Register all custom themes that we were given. 
       for (const themeName of Object.keys(this.cfg.customThemes || {})) {
-        const themeData = this.cfg.customThemes[themeName];
+        const themeData = assign({}, DefaultThemeData, this.cfg.customThemes[themeName]);
         if (themeData !== undefined) {
           monaco.editor.defineTheme(themeName, themeData);
         }

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/internal.d.ts
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/internal.d.ts
@@ -65,6 +65,7 @@ interface Helper {
   }>;
   resolveLocaleUrl: (options: Partial<PrimeFaces.widget.ExtMonacoEditorBaseCfgBase>) => string;
   BaseEditorDefaults: PrimeFaces.widget.ExtMonacoEditorBaseCfgBase;
+  DefaultThemeData: import("monaco-editor").editor.IStandaloneThemeData;
   FramedEditorDefaults: PrimeFaces.widget.ExtMonacoEditorFramedCfgBase;
   InlineEditorDefaults: PrimeFaces.widget.ExtMonacoEditorInlineCfgBase;
 }

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package-lock.json
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package-lock.json
@@ -5,11 +5,11 @@
   "packages": {
     "": {
       "dependencies": {
-        "primefaces": "^10.0.0"
+        "primefaces": "^11.0.0"
       },
       "devDependencies": {
         "@types/jquery": "^3.5.6",
-        "monaco-editor": "^0.27.0",
+        "monaco-editor": "^0.31.0",
         "typescript": "^4.4.2"
       }
     },
@@ -105,11 +105,10 @@
       "resolved": "https://registry.npmjs.org/@types/downloadjs/-/downloadjs-1.4.2.tgz",
       "integrity": "sha512-9UWO+nrRhwyKcFe45SFc98sWI8RGwpVwtZiZzi0W/dWdrp1SiUWFNANLlAXZb5QCMFDbeRiAQEhRn5btLd4a4w=="
     },
-    "node_modules/@types/googlemaps": {
-      "version": "3.43.3",
-      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.43.3.tgz",
-      "integrity": "sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==",
-      "deprecated": "Types for the Google Maps browser API have moved to @types/google.maps. Note: these types are not for the googlemaps npm package, which is a Node API."
+    "node_modules/@types/google.maps": {
+      "version": "3.47.2",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.47.2.tgz",
+      "integrity": "sha512-mFmt428CY4UN49U8KH5J4RfcdkeRu6SZyPIXxU1MA0pnHb4pqn/c/whawTodB3pkKWe8F9fXfUlpBFsk9HucXw=="
     },
     "node_modules/@types/hammerjs": {
       "version": "2.0.40",
@@ -169,8 +168,7 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "peer": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
@@ -186,8 +184,7 @@
     "node_modules/cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
-      "peer": true
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "node_modules/jsplumb": {
       "version": "2.15.6",
@@ -220,11 +217,10 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
-      "integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.0.tgz",
+      "integrity": "sha512-H3QmysEwxxY8oxmFhIFcY9JkuwilUDa6txdAxb797cVr7XFZX27a3SDwcGJmTlV9iGPwdh132r3KKCS5aNL4Gg==",
+      "dev": true
     },
     "node_modules/parchment": {
       "version": "1.1.4",
@@ -241,36 +237,68 @@
       }
     },
     "node_modules/primefaces": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/primefaces/-/primefaces-10.0.0.tgz",
-      "integrity": "sha512-O/Hb8JX9gHx5cumgUktgRYX5JOJy3NvNlnJ/6LjP5lw7kiPmXW8/cx3xPq2zAzxCBmuswnA2x5QsDyjM/ZoFHQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/primefaces/-/primefaces-11.0.0.tgz",
+      "integrity": "sha512-iaaYkDtEKuWEF58TnuhQuic6kSCM1ck+7CnDlMl6wty5IudTarIfgqGyOh6611FoaQWHnNR4j/XyAPOiIDYQLQ==",
+      "license": "MIT",
       "dependencies": {
-        "@fullcalendar/common": "^5.5.1",
-        "@fullcalendar/core": "^5.5.1",
-        "@fullcalendar/daygrid": "^5.5.0",
-        "@fullcalendar/interaction": "^5.5.0",
-        "@fullcalendar/list": "^5.5.0",
-        "@fullcalendar/moment": "^5.5.0",
-        "@fullcalendar/timegrid": "^5.5.1",
-        "@types/chart.js": "^2.9.31",
+        "@fullcalendar/common": "^5.9.0",
+        "@fullcalendar/core": "^5.9.0",
+        "@fullcalendar/daygrid": "^5.9.0",
+        "@fullcalendar/interaction": "^5.9.0",
+        "@fullcalendar/list": "^5.9.0",
+        "@fullcalendar/moment": "^5.9.0",
+        "@fullcalendar/timegrid": "^5.9.0",
+        "@types/chart.js": "^2.9.34",
         "@types/downloadjs": "^1.4.2",
-        "@types/googlemaps": "^3.43.3",
-        "@types/hammerjs": "^2.0.39",
-        "@types/inputmask": "^5.0.0",
-        "@types/jquery": "^3.5.5",
-        "@types/jqueryui": "^1.12.15",
-        "@types/js-cookie": "^2.2.6",
+        "@types/google.maps": "^3.45.6",
+        "@types/hammerjs": "^2.0.40",
+        "@types/inputmask": "^5.0.1",
+        "@types/jquery": "^3.5.6",
+        "@types/jqueryui": "^1.12.16",
+        "@types/js-cookie": "^2.2.7",
         "@types/quill": "~1.3.10",
-        "@types/raphael": "^2.3.1",
+        "@types/raphael": "^2.3.2",
         "autonumeric": "~4.6.0",
-        "cropperjs": "^1.5.11",
-        "jsplumb": "^2.15.5",
+        "cropperjs": "^1.5.12",
+        "jsplumb": "^2.15.6",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.33",
+        "print-js": "^1.6.0",
         "vis-data": "^7.1.2",
-        "vis-timeline": "^7.4.6",
-        "vis-util": "^5.0.2"
+        "vis-timeline": "^7.4.9",
+        "vis-util": "^5.0.2",
+        "xss": "^1.0.9"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "*",
+        "component-emitter": "*",
+        "keycharm": "*",
+        "propagating-hammerjs": "*",
+        "uuid": "*"
+      },
+      "peerDependenciesMeta": {
+        "@egjs/hammerjs": {
+          "optional": true
+        },
+        "component-emitter": {
+          "optional": true
+        },
+        "keycharm": {
+          "optional": true
+        },
+        "propagating-hammerjs": {
+          "optional": true
+        },
+        "uuid": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/print-js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/print-js/-/print-js-1.6.0.tgz",
+      "integrity": "sha512-BfnOIzSKbqGRtO4o0rnj/K3681BSd2QUrsIZy/+WdCIugjIswjmx3lDEZpXB2ruGf9d4b3YNINri81+J0FsBWg=="
     },
     "node_modules/propagating-hammerjs": {
       "version": "2.0.1",
@@ -363,7 +391,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.9.tgz",
       "integrity": "sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==",
-      "peer": true,
       "dependencies": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"
@@ -463,10 +490,10 @@
       "resolved": "https://registry.npmjs.org/@types/downloadjs/-/downloadjs-1.4.2.tgz",
       "integrity": "sha512-9UWO+nrRhwyKcFe45SFc98sWI8RGwpVwtZiZzi0W/dWdrp1SiUWFNANLlAXZb5QCMFDbeRiAQEhRn5btLd4a4w=="
     },
-    "@types/googlemaps": {
-      "version": "3.43.3",
-      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.43.3.tgz",
-      "integrity": "sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg=="
+    "@types/google.maps": {
+      "version": "3.47.2",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.47.2.tgz",
+      "integrity": "sha512-mFmt428CY4UN49U8KH5J4RfcdkeRu6SZyPIXxU1MA0pnHb4pqn/c/whawTodB3pkKWe8F9fXfUlpBFsk9HucXw=="
     },
     "@types/hammerjs": {
       "version": "2.0.40",
@@ -525,8 +552,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "peer": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -542,8 +568,7 @@
     "cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
-      "peer": true
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "jsplumb": {
       "version": "2.15.6",
@@ -570,9 +595,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
-      "integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.0.tgz",
+      "integrity": "sha512-H3QmysEwxxY8oxmFhIFcY9JkuwilUDa6txdAxb797cVr7XFZX27a3SDwcGJmTlV9iGPwdh132r3KKCS5aNL4Gg==",
       "dev": true
     },
     "parchment": {
@@ -586,36 +611,43 @@
       "integrity": "sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ=="
     },
     "primefaces": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/primefaces/-/primefaces-10.0.0.tgz",
-      "integrity": "sha512-O/Hb8JX9gHx5cumgUktgRYX5JOJy3NvNlnJ/6LjP5lw7kiPmXW8/cx3xPq2zAzxCBmuswnA2x5QsDyjM/ZoFHQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/primefaces/-/primefaces-11.0.0.tgz",
+      "integrity": "sha512-iaaYkDtEKuWEF58TnuhQuic6kSCM1ck+7CnDlMl6wty5IudTarIfgqGyOh6611FoaQWHnNR4j/XyAPOiIDYQLQ==",
       "requires": {
-        "@fullcalendar/common": "^5.5.1",
-        "@fullcalendar/core": "^5.5.1",
-        "@fullcalendar/daygrid": "^5.5.0",
-        "@fullcalendar/interaction": "^5.5.0",
-        "@fullcalendar/list": "^5.5.0",
-        "@fullcalendar/moment": "^5.5.0",
-        "@fullcalendar/timegrid": "^5.5.1",
-        "@types/chart.js": "^2.9.31",
+        "@fullcalendar/common": "^5.9.0",
+        "@fullcalendar/core": "^5.9.0",
+        "@fullcalendar/daygrid": "^5.9.0",
+        "@fullcalendar/interaction": "^5.9.0",
+        "@fullcalendar/list": "^5.9.0",
+        "@fullcalendar/moment": "^5.9.0",
+        "@fullcalendar/timegrid": "^5.9.0",
+        "@types/chart.js": "^2.9.34",
         "@types/downloadjs": "^1.4.2",
-        "@types/googlemaps": "^3.43.3",
-        "@types/hammerjs": "^2.0.39",
-        "@types/inputmask": "^5.0.0",
-        "@types/jquery": "^3.5.5",
-        "@types/jqueryui": "^1.12.15",
-        "@types/js-cookie": "^2.2.6",
+        "@types/google.maps": "^3.45.6",
+        "@types/hammerjs": "^2.0.40",
+        "@types/inputmask": "^5.0.1",
+        "@types/jquery": "^3.5.6",
+        "@types/jqueryui": "^1.12.16",
+        "@types/js-cookie": "^2.2.7",
         "@types/quill": "~1.3.10",
-        "@types/raphael": "^2.3.1",
+        "@types/raphael": "^2.3.2",
         "autonumeric": "~4.6.0",
-        "cropperjs": "^1.5.11",
-        "jsplumb": "^2.15.5",
+        "cropperjs": "^1.5.12",
+        "jsplumb": "^2.15.6",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.33",
+        "print-js": "^1.6.0",
         "vis-data": "^7.1.2",
-        "vis-timeline": "^7.4.6",
-        "vis-util": "^5.0.2"
+        "vis-timeline": "^7.4.9",
+        "vis-util": "^5.0.2",
+        "xss": "^1.0.9"
       }
+    },
+    "print-js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/print-js/-/print-js-1.6.0.tgz",
+      "integrity": "sha512-BfnOIzSKbqGRtO4o0rnj/K3681BSd2QUrsIZy/+WdCIugjIswjmx3lDEZpXB2ruGf9d4b3YNINri81+J0FsBWg=="
     },
     "propagating-hammerjs": {
       "version": "2.0.1",
@@ -663,7 +695,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.9.tgz",
       "integrity": "sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==",
-      "peer": true,
       "requires": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package.json
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package.json
@@ -1,13 +1,13 @@
 {
   "devDependencies": {
     "@types/jquery": "^3.5.6",
-    "monaco-editor": "^0.27.0",
+    "monaco-editor": "^0.31.0",
     "typescript": "^4.4.2"
   },
   "scripts": {
     "check": "tsc"
   },
   "dependencies": {
-    "primefaces": "^10.0.0"
+    "primefaces": "^11.0.0"
   }
 }

--- a/monacoeditor/src/main/js/descriptor/create.js
+++ b/monacoeditor/src/main/js/descriptor/create.js
@@ -60,6 +60,19 @@ clean(err => {
         column: Number(),
     }, "How to render vertical lines at the specified columns");
 
+    const EditorGuidesOptions = Class("EditorGuidesOptions", {
+        [Doc()]: "Enable rendering of bracket pair guides. Defaults to {@code false}.",
+        bracketPairs: Boolean(),
+        [Doc()]: "Enable rendering of vertical bracket pair guides. Defaults to {@code true}.",
+        bracketPairsHorizontal: Boolean(),
+        [Doc()]: "Enable highlighting of the active bracket pair. Defaults to {@code true}.",
+        highlightActiveBracketPair: Boolean(),
+        [Doc()]: "Enable highlighting of the active indent guide. Defaults to {@code true}.",
+        highlightActiveIndentation: Boolean(),
+        [Doc()]: "Enable rendering of indent guides. Defaults to {@code true}.",
+        indentation: Boolean(),
+    }, "Controls the behavior of editor guides.");
+
     const EditorGotoLocationOptions = Class("EditorGotoLocationOptions", {
         alternativeDeclarationCommand: String(),
         alternativeDefinitionCommand: String(),
@@ -75,6 +88,9 @@ clean(err => {
     }, "Configuration options for go to location");
 
     const EditorHoverOptions = Class("EditorHoverOptions", {
+        [Doc()]: "Should the hover be shown above the line if possible? Defaults to {@code false}.",
+        above: Boolean(),
+
         [Doc()]: "Delay for showing the hover. Defaults to 300.",
         delay: Number(),
 
@@ -193,6 +209,15 @@ clean(err => {
         verticalSliderSize: Number(),
     }, "Configuration options for editor scrollbars");
 
+    const EditorUnicodeHighlightOptions = Class("EditorUnicodeHighlightOptions", {
+        [Doc()]: "A map of allowed characters ({@code true}: allowed).",
+        allowedCharacters: Map(String(), Boolean()),
+        ambiguousCharacters: Boolean(),
+        includeComments: Boolean(),
+        invisibleCharacters: Boolean(),
+        nonBasicASCII: Boolean(),
+    }, "Defines how Unicode characters should be highlighted.");
+
     const EditorSuggestOptions = Class("EditorSuggestOptions", {
         [Doc()]: "Enable graceful matching. Defaults to {@code true}.",
         filterGraceful: Boolean(),
@@ -202,9 +227,6 @@ clean(err => {
 
         [Doc()]: "Favours words that appear close to the cursor.",
         localityBonus: Boolean(),
-
-        [Doc()]: "Max suggestions to show in suggestions. Defaults to {@code 12}.",
-        maxVisibleSuggestions: Boolean(),
 
         [Doc()]: "Enable or disable the rendering of the suggestion preview.",
         preview: Boolean(),
@@ -346,6 +368,9 @@ clean(err => {
         [Doc()]: "Control the behavior of the find widget.",
         find: EditorFindOptions,
 
+        [Doc()]: "Controls the behavior of editor guides.",
+        guides: EditorGuidesOptions,
+
         gotoLocation: EditorGotoLocationOptions,
 
         [Doc()]: "Configure the editor's hover.",
@@ -380,6 +405,9 @@ clean(err => {
 
         [Doc()]: "Suggest options.",
         suggest: EditorSuggestOptions,
+
+        [Doc()]: "Defines how Unicode characters should be highlighted.",
+        unicodeHighlight: EditorUnicodeHighlightOptions,
 
         [Doc()]: "Options for typing over closing quotes or brackets.",
         autoClosingOvertype: Enum(
@@ -454,6 +482,7 @@ clean(err => {
             "dart",
             "dockerfile",
             "ecl",
+            "flow9",
             "fsharp",
             "go",
             "graphql",
@@ -480,10 +509,12 @@ clean(err => {
             "perl",
             "pgsql",
             "php",
+            "pla",
             "plaintext",
             "postiats",
             "powerquery",
             "powershell",
+            "proto",
             "pug",
             "python",
             "r",
@@ -650,9 +681,6 @@ clean(err => {
         [Doc()]: "Should the cursor be hidden in the overview ruler. Defaults to {@code false}",
         hideCursorInOverviewRuler: Boolean(),
 
-        [Doc()]: "Enable highlighting of the active indent guide. Defaults to {@code true}.",
-        highlightActiveIndentGuide: Boolean(),
-
         [Doc()]: "Insert spaces when pressing {@code Tab}. This setting is overridden based on the file contents when {@code detectIndentation} is on. Defaults to {@code true}.",
         insertSpaces: Boolean(),
 
@@ -687,14 +715,11 @@ clean(err => {
         [Doc()]: "Deprecated, use {@link linkedEditing} instead.",
         renameOnType: Boolean(),
 
-        [Doc()]: "Enable rendering of control characters. Defaults to {@code false}.",
+        [Doc()]: "Enable rendering of control characters. Defaults to {@code true}.",
         renderControlCharacters: Boolean(),
 
         [Doc()]: "Render last line number when the file ends with a newline. Defaults to {@code true}.",
         renderFinalNewline: Boolean(),
-
-        [Doc()]: "Enable rendering of indent guides. Defaults to {@code true}.",
-        renderIndentGuides: Boolean(),
 
         [Doc()]: "Control if the current line highlight should be rendered only the editor is focused. Defaults to {@code false}.",
         renderLineHighlightOnlyWhenFocus: Boolean(),
@@ -869,18 +894,18 @@ clean(err => {
     }, "Defines how to style a certain token in the Monaco code editor.");
 
     const EditorStandaloneTheme = Class("EditorStandaloneTheme", {
-        [Doc()]: "Base theme from which to extend when {@inherit} is set to {@code true}.",
+        [Doc()]: "Base theme from which to extend when {@inherit} is set to {@code true}. This is required, when not set it defaults to {@code vs}.",
         base: ETheme,
 
-        [Doc()]: "Map between the color ID and the CSS color to use.",
+        [Doc()]: "Map between the color ID and the CSS color to use. This is required, when not set, it defaults to an empty map.",
         colors: Map(String(), String()),
 
         encodedTokensColors: Array(String()),
 
-        [Doc()]: "Whether this theme should inherit from the given base theme.",
+        [Doc()]: "Whether this theme should inherit from the given base theme. This is required, when not set it defaults to {@code false}.",
         inherit: Boolean(),
 
-        [Doc()]: "Styling options for individual token types, such as how to style variables, certain keywords, and parentheses.",
+        [Doc()]: "Styling options for individual token types, such as how to style variables, certain keywords, and parentheses. This is required, when not set it defaults to an empty array.",
         rules: Array(EditorTokenThemeRule),
     }, "Data that defines a custom theme for the Monaco code editor");
 })

--- a/monacoeditor/src/main/js/generateLocales.js
+++ b/monacoeditor/src/main/js/generateLocales.js
@@ -96,7 +96,7 @@ function injectSourcePath(callback) {
                         const transPath = vsPath + "/" + path.basename(file, ".js");
                         replaceInFile(file,
                             [
-                                /localize\(/g,
+                                /(?<!function\s+)localize\(/g,
                                 `localize('${transPath}', `,
                             ],
                             [

--- a/monacoeditor/src/main/js/package-lock.json
+++ b/monacoeditor/src/main/js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "insane": "^2.6.2",
-        "monaco-editor": "^0.30.1"
+        "monaco-editor": "^0.31.0"
       },
       "devDependencies": {
         "@types/jquery": "^3.5.10",
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
-      "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.0.tgz",
+      "integrity": "sha512-H3QmysEwxxY8oxmFhIFcY9JkuwilUDa6txdAxb797cVr7XFZX27a3SDwcGJmTlV9iGPwdh132r3KKCS5aNL4Gg=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -2700,9 +2700,9 @@
       "dev": true
     },
     "monaco-editor": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
-      "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.0.tgz",
+      "integrity": "sha512-H3QmysEwxxY8oxmFhIFcY9JkuwilUDa6txdAxb797cVr7XFZX27a3SDwcGJmTlV9iGPwdh132r3KKCS5aNL4Gg=="
     },
     "ms": {
       "version": "2.1.2",

--- a/monacoeditor/src/main/js/package.json
+++ b/monacoeditor/src/main/js/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "insane": "^2.6.2",
-    "monaco-editor": "^0.30.1"
+    "monaco-editor": "^0.31.0"
   },
   "devDependencies": {
     "@types/jquery": "^3.5.10",

--- a/pom.xml
+++ b/pom.xml
@@ -374,8 +374,8 @@
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>1.12.0</version>
                     <configuration>
-                        <nodeVersion>v15.8.0</nodeVersion>
-                        <npmVersion>7.5.1</npmVersion>
+                        <nodeVersion>v16.13.1</nodeVersion>
+                        <npmVersion>8.1.2</npmVersion>
                         <installDirectory>${main.basedir}/target/node</installDirectory>
                     </configuration>
                 </plugin>

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/util/MonacoEditorSettings.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/util/MonacoEditorSettings.java
@@ -56,20 +56,18 @@ public class MonacoEditorSettings {
      */
     public static List<Locale> getBuiltInLocales() {
         return Arrays.asList( //
-                    new Locale("bg"),
+                    new Locale("cs"),
                     new Locale("de"),
                     new Locale("en"),
                     new Locale("es"),
                     new Locale("fr"),
-                    new Locale("hu"),
                     new Locale("it"),
                     new Locale("ja"),
                     new Locale("ko"),
-                    new Locale("ps"),
+                    new Locale("pl"),
                     new Locale("pt", "BR"),
                     new Locale("ru"),
                     new Locale("tr"),
-                    new Locale("uk"),
                     new Locale("zh", "CN"),
                     new Locale("zh", "TW"));
     }


### PR DESCRIPTION
* See #651
* Fix monaco build error
* Use LTS version of node.js / NPM for building (16 / 8)
* Update Java wrapper for editor options: https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html
* Update available locales shipped with monaco editor: https://github.com/microsoft/vscode-loc/tree/main/i18n
* Use defaults for required theme settings, this was broken: https://www.primefaces.org/showcase-ext/sections/monacoEditor/customTheme.jsf

__HOWEVER__ before releasing an extension version we should wait for https://github.com/microsoft/monaco-editor/issues/2822 to be fixed (hopefully in 0.31.1, seems easy to fix, but can make the editor hard to use)
