### PR TITLE
MorphiaLazyDataModel: Implements some of the missing match modes

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
+++ b/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
@@ -262,7 +262,7 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
                                 }
                                 break;
                             case NOT_CONTAINS:
-                                 q.filter(Filters.regex(field).pattern(val + "").caseInsensitive().not());
+                                 q.filter(Filters.regex(field).pattern(val + Constants.EMPTY_STRING).caseInsensitive().not());
 
                                 break;
                                 

--- a/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
+++ b/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
@@ -254,7 +254,7 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
                                 
                             case BETWEEN:
                                 if (metadata.getFilterValue().getClass() == ArrayList.class) {
-                                    final List dates = (ArrayList) metadata.getFilterValue();
+                                    final List<?> dates = (List) metadata.getFilterValue();
                                     if (dates.size() > 1){ //does this ever have less than 2 items?
                                         q.filter(Filters.gt(field, dates.get(0)),Filters.lt(field,dates.get(1)));
                                     }

--- a/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
+++ b/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
@@ -285,7 +285,7 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
                                 break;
                             case NOT_IN:
                                 
-                                if (metadata.getFilterValue().getClass() == Object[].class) {
+                                if (metadata.getFilterValue() instanceof Object[]) {
                                     final Object[] parts = (Object[]) metadata.getFilterValue();
                                     q.filter(Filters.nin(field, Arrays.asList(parts)));
                                 }

--- a/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
+++ b/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
@@ -253,7 +253,7 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
                                 break;
                                 
                             case BETWEEN:
-                                if (metadata.getFilterValue().getClass() == ArrayList.class) {
+                                if (metadata.getFilterValue() instanceof List) {
                                     final List<?> dates = (List) metadata.getFilterValue();
                                     if (dates.size() > 1){ //does this ever have less than 2 items?
                                         q.filter(Filters.gt(field, dates.get(0)),Filters.lt(field,dates.get(1)));

--- a/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
+++ b/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
@@ -40,6 +40,7 @@ import javax.faces.FacesException;
 import org.primefaces.model.FilterMeta;
 import org.primefaces.model.LazyDataModel;
 import org.primefaces.model.SortMeta;
+import org.primefaces.util.Constants;
 import org.primefaces.util.Lazy;
 
 import dev.morphia.Datastore;
@@ -48,7 +49,6 @@ import dev.morphia.query.Query;
 import dev.morphia.query.Sort;
 import dev.morphia.query.experimental.filters.Filters;
 import dev.morphia.query.experimental.filters.RegexFilter;
-import java.util.ArrayList;
 
 /**
  * Basic {@link LazyDataModel} implementation for MongoDB using Morphia.
@@ -71,7 +71,7 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
     private final Map<String, BiConsumer<Query<T>, FilterMeta>> overrides = new HashMap<>();
     // consumer to be executed before the query is built, useful to modify the original query
     private transient Consumer<Query<T>> prependConsumer;
-    //global filter consumer (to be implemented by the user)
+    // global filter consumer (to be implemented by the user)
     private transient BiConsumer<Query<T>, FilterMeta> globalFilterConsumer;
 
     /**
@@ -195,7 +195,7 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
                                 final Object castedValueEx = castedValue(field, val);
                                 if (castedValueEx != null) {
                                     q.filter(Filters.eq(field, castedValueEx));
-                                }  
+                                }
                                 else {
                                     q.filter(Filters.eq(field, val));
                                 }
@@ -251,21 +251,21 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
                                 }
 
                                 break;
-                                
+
                             case BETWEEN:
                                 if (metadata.getFilterValue() instanceof List) {
                                     final List<?> dates = (List) metadata.getFilterValue();
-                                    if (dates.size() > 1){ //does this ever have less than 2 items?
-                                        q.filter(Filters.gt(field, dates.get(0)),Filters.lt(field,dates.get(1)));
+                                    if (dates.size() > 1) { // does this ever have less than 2 items?
+                                        q.filter(Filters.gte(field, dates.get(0)), Filters.lte(field, dates.get(1)));
                                     }
-                                  
+
                                 }
                                 break;
                             case NOT_CONTAINS:
-                                 q.filter(Filters.regex(field).pattern(val + Constants.EMPTY_STRING).caseInsensitive().not());
+                                q.filter(Filters.regex(field).pattern(val + Constants.EMPTY_STRING).caseInsensitive().not());
 
                                 break;
-                                
+
                             case NOT_EQUALS:
                                 final Object castedValueNe = castedValue(field, val);
                                 if (castedValueNe != null) {
@@ -277,14 +277,14 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
 
                                 break;
                             case NOT_STARTS_WITH:
-                                
+
                                 final RegexFilter regStartsWithNot = Filters.regex(field);
                                 regStartsWithNot.pattern("^" + val).caseInsensitive();
                                 q.filter(regStartsWithNot.not());
 
                                 break;
                             case NOT_IN:
-                                
+
                                 if (metadata.getFilterValue() instanceof Object[]) {
                                     final Object[] parts = (Object[]) metadata.getFilterValue();
                                     q.filter(Filters.nin(field, Arrays.asList(parts)));
@@ -292,20 +292,18 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
 
                                 break;
                             case NOT_ENDS_WITH:
-                                
+
                                 final RegexFilter regEndsWithNot = Filters.regex(field);
                                 regEndsWithNot.pattern(val + "$").caseInsensitive();
                                 q.filter(regEndsWithNot.not());
 
                                 break;
                             case GLOBAL:
-                                
-                                if (globalFilterConsumer != null){
-                                    globalFilterConsumer.accept(q,metadata );
+
+                                if (globalFilterConsumer != null) {
+                                    globalFilterConsumer.accept(q, metadata);
                                 }
                                 break;
-                              
-
 
                             default:
                                 throw new UnsupportedOperationException(
@@ -322,7 +320,8 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
         this.prependConsumer = consumer;
         return this;
     }
-     public MorphiaLazyDataModel<T> globalFilter(final BiConsumer<Query<T>, FilterMeta> consumer) {
+
+    public MorphiaLazyDataModel<T> globalFilter(final BiConsumer<Query<T>, FilterMeta> consumer) {
         this.globalFilterConsumer = consumer;
         return this;
     }

--- a/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
+++ b/core/src/main/java/org/primefaces/extensions/model/mongo/MorphiaLazyDataModel.java
@@ -48,6 +48,7 @@ import dev.morphia.query.Query;
 import dev.morphia.query.Sort;
 import dev.morphia.query.experimental.filters.Filters;
 import dev.morphia.query.experimental.filters.RegexFilter;
+import java.util.ArrayList;
 
 /**
  * Basic {@link LazyDataModel} implementation for MongoDB using Morphia.
@@ -70,6 +71,8 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
     private final Map<String, BiConsumer<Query<T>, FilterMeta>> overrides = new HashMap<>();
     // consumer to be executed before the query is built, useful to modify the original query
     private transient Consumer<Query<T>> prependConsumer;
+    //global filter consumer (to be implemented by the user)
+    private transient BiConsumer<Query<T>, FilterMeta> globalFilterConsumer;
 
     /**
      * For serialization only
@@ -192,7 +195,7 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
                                 final Object castedValueEx = castedValue(field, val);
                                 if (castedValueEx != null) {
                                     q.filter(Filters.eq(field, castedValueEx));
-                                }
+                                }  
                                 else {
                                     q.filter(Filters.eq(field, val));
                                 }
@@ -248,6 +251,61 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
                                 }
 
                                 break;
+                                
+                            case BETWEEN:
+                                if (metadata.getFilterValue().getClass() == ArrayList.class) {
+                                    final List dates = (ArrayList) metadata.getFilterValue();
+                                    if (dates.size() > 1){ //does this ever have less than 2 items?
+                                        q.filter(Filters.gt(field, dates.get(0)),Filters.lt(field,dates.get(1)));
+                                    }
+                                  
+                                }
+                                break;
+                            case NOT_CONTAINS:
+                                 q.filter(Filters.regex(field).pattern(val + "").caseInsensitive().not());
+
+                                break;
+                                
+                            case NOT_EQUALS:
+                                final Object castedValueNe = castedValue(field, val);
+                                if (castedValueNe != null) {
+                                    q.filter(Filters.eq(field, castedValueNe).not());
+                                }
+                                else {
+                                    q.filter(Filters.eq(field, val).not());
+                                }
+
+                                break;
+                            case NOT_STARTS_WITH:
+                                
+                                final RegexFilter regStartsWithNot = Filters.regex(field);
+                                regStartsWithNot.pattern("^" + val).caseInsensitive();
+                                q.filter(regStartsWithNot.not());
+
+                                break;
+                            case NOT_IN:
+                                
+                                if (metadata.getFilterValue().getClass() == Object[].class) {
+                                    final Object[] parts = (Object[]) metadata.getFilterValue();
+                                    q.filter(Filters.nin(field, Arrays.asList(parts)));
+                                }
+
+                                break;
+                            case NOT_ENDS_WITH:
+                                
+                                final RegexFilter regEndsWithNot = Filters.regex(field);
+                                regEndsWithNot.pattern(val + "$").caseInsensitive();
+                                q.filter(regEndsWithNot.not());
+
+                                break;
+                            case GLOBAL:
+                                
+                                if (globalFilterConsumer != null){
+                                    globalFilterConsumer.accept(q,metadata );
+                                }
+                                break;
+                              
+
 
                             default:
                                 throw new UnsupportedOperationException(
@@ -261,7 +319,11 @@ public class MorphiaLazyDataModel<T> extends LazyDataModel<T> implements Seriali
     }
 
     public MorphiaLazyDataModel<T> prependQuery(final Consumer<Query<T>> consumer) {
-        prependConsumer = consumer;
+        this.prependConsumer = consumer;
+        return this;
+    }
+     public MorphiaLazyDataModel<T> globalFilter(final BiConsumer<Query<T>, FilterMeta> consumer) {
+        this.globalFilterConsumer = consumer;
         return this;
     }
 


### PR DESCRIPTION
Implements the following missing match modes:
- BETWEEN
- NOT_CONTAINS
- NOT_EQUALS
- NOT_STARTS_WITH
- NOT_ENDS_WITH
- NOT_IN
- GLOBAL (this one is expected to implemented by the user using the new .globalFilter(BiConsumer) method, since this wouldn't be possible to implement in a generic manner without having deep knowledge of the model being used)

I think this covers all the cases for this datamodel to be used in any scenario when morphia is used, making it unnecessary to ever need to create a custom morphia DataModel.

For cases when a complex field filter is needed which is not covered by the match modes on this datamodel, use:
- overrideFieldQuery(field, BiConsumer<Query, FilterMeta>)

For cases where you need to add more stuff to the query that doesn't depend on filters use:
- prependQuery(Consumer<Query>)

For cases where you want to implment a globalFiter use:
- globalFilter(BiConsumer<Query, FilterMeta>)