### PR TITLE
Fixes #785, apply value upon initialization

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/03-monaco-widget-base.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/03-monaco-widget-base.js
@@ -222,9 +222,9 @@ window.monacoModule = window.monacoModule || {};
      * @returns {Promise<void>}
      */
     async _onInitSuccess() {
+      this.jq.data("initialized", true);
       await this.setValue(this._editorValue || "");
       this._fireEvent("initialized");
-      this.jq.data("initialized", true);
       for (const { resolve } of this._onDone || []) {
         resolve(this);
       }


### PR DESCRIPTION
Simple fixes are the best. By setting the `initialized` attribute before calling `setValue`, said function actually sets the value instead of just remembering it for later.

Can be tested e.g. in the playground (https://www.primefaces.org/showcase-ext/sections/monacoEditor/extender.jsf?example=jquery) by calling `setValueNow` in the `afterCreate` callback of the extender. Before this fix, the value was not applied, now it is

```javascript
/**
 * @return {PrimeFaces.widget.ExtMonacoEditor.ExtenderCodeEditorInline}
 */
function createExtender() {
  return {
    async afterCreate(context) {
      context.setValueNow("const helloWord = 42");
    }
  };
}
```
