### PR TITLE
Update mkdirp and rimraf

### DIFF
--- a/monacoeditor/src/main/js/package-lock.json
+++ b/monacoeditor/src/main/js/package-lock.json
@@ -17,7 +17,7 @@
         "@types/cross-spawn": "^6.0.2",
         "@types/jquery": "^3.5.16",
         "css-loader": "^6.7.1",
-        "mkdirp": "^2.1.6",
+        "mkdirp": "^3.0.0",
         "ncp": "^2.0.0",
         "recursive-readdir": "^2.2.3",
         "rimraf": "^4.4.1",
@@ -985,9 +985,9 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
-      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.0.tgz",
+      "integrity": "sha512-7+JDnNsyCvZXoUJdkMR0oUE2AmAdsNXGTmRbiOjYIwQ6q+bL6NwrozGQdPcmYaNcrhH37F50HHBUzoaBV6FITQ==",
       "dev": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -2534,9 +2534,9 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
-      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.0.tgz",
+      "integrity": "sha512-7+JDnNsyCvZXoUJdkMR0oUE2AmAdsNXGTmRbiOjYIwQ6q+bL6NwrozGQdPcmYaNcrhH37F50HHBUzoaBV6FITQ==",
       "dev": true
     },
     "monaco-editor": {

--- a/monacoeditor/src/main/js/package-lock.json
+++ b/monacoeditor/src/main/js/package-lock.json
@@ -20,7 +20,7 @@
         "mkdirp": "^2.1.6",
         "ncp": "^2.0.0",
         "recursive-readdir": "^2.2.3",
-        "rimraf": "^4.4.1",
+        "rimraf": "^5.0.0",
         "style-loader": "^3.3.2",
         "terser-webpack-plugin": "^5.3.7",
         "typescript": "^5.0.4",
@@ -702,15 +702,15 @@
       "dev": true
     },
     "node_modules/glob": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.2.1.tgz",
-      "integrity": "sha512-Pxxgq3W0HyA3XUvSXcFhRSs+43Jsx0ddxcFrbjxNGkL2Ak5BAUBxLqI5G6ADDeCHLfzzXFhe0b1yYcctGmytMA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.0.0.tgz",
+      "integrity": "sha512-zmp9ZDC6NpDNLujV2W2n+3lH+BafIVZ4/ct+Yj3BMZTH/+bgm/eVjHzeFLwxJrrIGgjjS2eiQLlpurHsNlEAtQ==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "minimatch": "^7.4.1",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "minimatch": "^9.0.0",
+        "minipass": "^5.0.0",
+        "path-scurry": "^1.6.4"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -735,15 +735,15 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
-      "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.4.tgz",
-      "integrity": "sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -1103,28 +1103,28 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.1.tgz",
-      "integrity": "sha512-OW+5s+7cw6253Q4E+8qQ/u1fVvcJQCJo/VFD8pje+dbJCF1n5ZRMV2AEHbGp+5Q7jxQIYJxkHopnj6nzdGeZLA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.4.tgz",
+      "integrity": "sha512-Qp/9IHkdNiXJ3/Kon++At2nVpnhRiPq/aSvQN+H3U1WZbvNRK0RIQK/o4HMqPoXjpuGJUEWpHSs6Mnjxqh3TQg==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^7.14.1",
-        "minipass": "^4.0.2"
+        "lru-cache": "^9.0.0",
+        "minipass": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.1.tgz",
-      "integrity": "sha512-8/HcIENyQnfUTCDizRu9rrDyG6XG/21M4X7/YEGZeD76ZJilFPAUVb/2zysFf7VVO1LEjCDFyHp8pMMvozIrvg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.0.0.tgz",
+      "integrity": "sha512-9AEKXzvOZc4BMacFnYiTOlDH/197LNnQIK9wZ6iMB5NXPzuv4bWR/Msv7iUMplkiMQ1qQL+KSv/JF1mZAB5Lrg==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=16.14"
       }
     },
     "node_modules/picocolors": {
@@ -1328,12 +1328,12 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.0.tgz",
+      "integrity": "sha512-Jf9llaP+RvaEVS5nPShYFhtXIrb3LRKP281ib3So0KkeZKo2wIKyq0Re7TOSwanasA423PSr6CCIL4bP6T040g==",
       "dev": true,
       "dependencies": {
-        "glob": "^9.2.0"
+        "glob": "^10.0.0"
       },
       "bin": {
         "rimraf": "dist/cjs/src/bin.js"
@@ -2320,15 +2320,15 @@
       "dev": true
     },
     "glob": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.2.1.tgz",
-      "integrity": "sha512-Pxxgq3W0HyA3XUvSXcFhRSs+43Jsx0ddxcFrbjxNGkL2Ak5BAUBxLqI5G6ADDeCHLfzzXFhe0b1yYcctGmytMA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.0.0.tgz",
+      "integrity": "sha512-zmp9ZDC6NpDNLujV2W2n+3lH+BafIVZ4/ct+Yj3BMZTH/+bgm/eVjHzeFLwxJrrIGgjjS2eiQLlpurHsNlEAtQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
-        "minimatch": "^7.4.1",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "minimatch": "^9.0.0",
+        "minipass": "^5.0.0",
+        "path-scurry": "^1.6.4"
       },
       "dependencies": {
         "brace-expansion": {
@@ -2341,9 +2341,9 @@
           }
         },
         "minimatch": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
-          "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+          "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -2528,9 +2528,9 @@
       }
     },
     "minipass": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.4.tgz",
-      "integrity": "sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true
     },
     "mkdirp": {
@@ -2618,19 +2618,19 @@
       "dev": true
     },
     "path-scurry": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.1.tgz",
-      "integrity": "sha512-OW+5s+7cw6253Q4E+8qQ/u1fVvcJQCJo/VFD8pje+dbJCF1n5ZRMV2AEHbGp+5Q7jxQIYJxkHopnj6nzdGeZLA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.4.tgz",
+      "integrity": "sha512-Qp/9IHkdNiXJ3/Kon++At2nVpnhRiPq/aSvQN+H3U1WZbvNRK0RIQK/o4HMqPoXjpuGJUEWpHSs6Mnjxqh3TQg==",
       "dev": true,
       "requires": {
-        "lru-cache": "^7.14.1",
-        "minipass": "^4.0.2"
+        "lru-cache": "^9.0.0",
+        "minipass": "^5.0.0"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "7.18.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.1.tgz",
-          "integrity": "sha512-8/HcIENyQnfUTCDizRu9rrDyG6XG/21M4X7/YEGZeD76ZJilFPAUVb/2zysFf7VVO1LEjCDFyHp8pMMvozIrvg==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.0.0.tgz",
+          "integrity": "sha512-9AEKXzvOZc4BMacFnYiTOlDH/197LNnQIK9wZ6iMB5NXPzuv4bWR/Msv7iUMplkiMQ1qQL+KSv/JF1mZAB5Lrg==",
           "dev": true
         }
       }
@@ -2773,12 +2773,12 @@
       "dev": true
     },
     "rimraf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.0.tgz",
+      "integrity": "sha512-Jf9llaP+RvaEVS5nPShYFhtXIrb3LRKP281ib3So0KkeZKo2wIKyq0Re7TOSwanasA423PSr6CCIL4bP6T040g==",
       "dev": true,
       "requires": {
-        "glob": "^9.2.0"
+        "glob": "^10.0.0"
       }
     },
     "safe-buffer": {

--- a/monacoeditor/src/main/js/package.json
+++ b/monacoeditor/src/main/js/package.json
@@ -21,7 +21,7 @@
     "@types/cross-spawn": "^6.0.2",
     "@types/jquery": "^3.5.16",
     "css-loader": "^6.7.1",
-    "mkdirp": "^2.1.6",
+    "mkdirp": "^3.0.0",
     "ncp": "^2.0.0",
     "recursive-readdir": "^2.2.3",
     "rimraf": "^4.4.1",

--- a/monacoeditor/src/main/js/package.json
+++ b/monacoeditor/src/main/js/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^2.1.6",
     "ncp": "^2.0.0",
     "recursive-readdir": "^2.2.3",
-    "rimraf": "^4.4.1",
+    "rimraf": "^5.0.0",
     "style-loader": "^3.3.2",
     "terser-webpack-plugin": "^5.3.7",
     "typescript": "^5.0.4",

--- a/monacoeditor/src/main/js/src/scripts/generateLocales.js
+++ b/monacoeditor/src/main/js/src/scripts/generateLocales.js
@@ -6,7 +6,7 @@ import { basename, dirname, join, relative } from "node:path";
 import { mkdirpNative } from "mkdirp";
 import ncp from "ncp";
 import recursive from "recursive-readdir";
-import rimraf from "rimraf";
+import { rimraf } from "rimraf";
 
 import { gitUpdateToTheirs } from "../util/git-clone-or-pull.js";
 

--- a/monacoeditor/src/main/js/src/scripts/generateLocales.js
+++ b/monacoeditor/src/main/js/src/scripts/generateLocales.js
@@ -3,7 +3,7 @@
 import { promises as fs } from "node:fs";
 import { basename, dirname, join, relative } from "node:path";
 
-import mkdirp from "mkdirp";
+import { mkdirpNative } from "mkdirp";
 import ncp from "ncp";
 import recursive from "recursive-readdir";
 import rimraf from "rimraf";
@@ -246,7 +246,7 @@ function extractLocaleCode(dir) {
 }
 
 async function main() {
-    await mkdirp.native(gitDir);
+    await mkdirpNative(gitDir);
     await injectSourcePath();
 
     // Fetch the locale data from the github repo
@@ -267,7 +267,7 @@ async function main() {
             continue;
         }
         const locale = await createLocale(lang, transPath);
-        await mkdirp.native(generatedSourceLocaleDir)
+        await mkdirpNative(generatedSourceLocaleDir)
         const mappedLang = lang;
         const path = join(generatedSourceLocaleDir, mappedLang + ".js");
         const content = createScript(mappedLang, locale);

--- a/monacoeditor/src/main/js/src/util/java-types.js
+++ b/monacoeditor/src/main/js/src/util/java-types.js
@@ -3,7 +3,7 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import rimraf from "rimraf";
-import mkdirp from "mkdirp";
+import { mkdirp } from "mkdirp";
 
 import { javaDescriptorPackage, javaDescriptorPath } from "./paths.js";
 

--- a/monacoeditor/src/main/js/src/util/java-types.js
+++ b/monacoeditor/src/main/js/src/util/java-types.js
@@ -2,7 +2,7 @@
 
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
-import rimraf from "rimraf";
+import { rimraf } from "rimraf";
 import { mkdirp } from "mkdirp";
 
 import { javaDescriptorPackage, javaDescriptorPath } from "./paths.js";


### PR DESCRIPTION
This contains the commits from both #1147 and #1148 and fixes the imports from the mkdirp and rimraf update. I also tested it with the showcase, Monaco Editor is still working.