### PR TITLE
Typo primefaces-extensions.taglib.xml

### DIFF
--- a/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -7074,7 +7074,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Timeout in seconds to do the ajax ajax requests. Default is 10.]]>
+                <![CDATA[Timeout in seconds to do the Ajax request(s). Default is 10.]]>
             </description>
             <name>timeout</name>
             <required>false</required>


### PR DESCRIPTION
@melloware By the way, I was not able to directly save the file. That was possible before.

<img width="513" alt="Screenshot 2023-05-11 at 12 52 03" src="https://github.com/primefaces-extensions/primefaces-extensions/assets/7500178/3ac46e6c-8fdd-4220-8edd-5bfc07d01c29">
