### PR TITLE
Fixes #718, move Monaco editor options Java class files to core module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -654,6 +654,17 @@
                             <testFailureIgnore>true</testFailureIgnore>
                         </configuration>
                     </execution>
+                    <!-- Generate editor options -->
+                    <execution>
+                        <id>generate editor options</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>run generate-editor-options</arguments>
+                        </configuration>
+                    </execution>
                     <!-- Check typings -->
                     <execution>
                         <id>pfe-check-monaco-widget-typings</id>
@@ -663,6 +674,25 @@
                         <phase>verify</phase>
                         <configuration>
                             <arguments>run verify</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Make generated Java files available -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>include-generated-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/target/generated-sources/java/</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package-lock.json
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package-lock.json
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@types/jquery": "^3.5.6",
+        "@types/node": "^20.10.6",
         "monaco-editor": "^0.31.0",
         "patch-package": "^6.4.7",
         "typescript": "^4.5.5"
@@ -142,6 +143,15 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
       "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/quill": {
       "version": "1.3.10",
@@ -820,6 +830,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -1045,6 +1061,15 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
       "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
+    "@types/node": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/quill": {
       "version": "1.3.10",
@@ -1571,6 +1596,12 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "universalify": {

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package.json
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package.json
@@ -1,13 +1,15 @@
 {
   "devDependencies": {
     "@types/jquery": "^3.5.6",
+    "@types/node": "^20.10.6",
     "monaco-editor": "^0.31.0",
     "patch-package": "^6.4.7",
     "typescript": "^4.5.5"
   },
   "scripts": {
     "verify": "tsc --noEmit",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "generate-editor-options": "node scripts/generateEditorOptions.js"
   },
   "dependencies": {
     "primefaces": "^11.0.0"

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/scripts/generateEditorOptions.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/scripts/generateEditorOptions.js
@@ -6,7 +6,7 @@
 // 
 // This is used to create corresponding Java classes for configuring the monaco editor widget.
 
-import {
+const {
     cleanJavaDescriptors,
     Deprecated,
     Doc,
@@ -20,7 +20,7 @@ import {
     T_Map,
     T_Number,
     T_String
-} from "../util/java-types.js";
+} = require("./java-types.js");
 
 async function main() {
     await cleanJavaDescriptors();

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/scripts/java-types.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/scripts/java-types.js
@@ -1,11 +1,14 @@
 // @ts-check
 
-import { promises as fs } from "node:fs";
-import { join } from "node:path";
-import { rimraf } from "rimraf";
-import { mkdirp } from "mkdirp";
+/// <reference types="node" />
 
-import { javaDescriptorPackage, javaDescriptorPath } from "./paths.js";
+const { promises: fs } = require("node:fs");
+const { join } = require("node:path");
+
+const projectDir = join(__dirname, "..", "..", "..", "..", "..", "..", "..", "..");
+const targetDir = join(projectDir, "target");
+const javaDescriptorPackage = "org.primefaces.extensions.model.monacoeditor";
+const javaDescriptorPath = join(targetDir, "generated-sources", "java", "org", "primefaces", "extensions", "model", "monacoeditor");
 
 /** {@type string} */
 const HeaderComment = `
@@ -97,7 +100,7 @@ function notEmpty(value) {
  * @param {string} [data] 
  * @returns {string}
  */
-export function Doc(data) {
+function Doc(data) {
   if (data) {
     return `@Doc${data}`;
   }
@@ -110,7 +113,7 @@ export function Doc(data) {
  * @param {string} [data]
  * @returns {string}
  */
-export function Deprecated(data) {
+function Deprecated(data) {
   if (data) {
     return `@Deprecated${data}`;
   }
@@ -267,9 +270,9 @@ function createAddMapEntryDoc(docString, deprecationNotice) {
 /**
  * @returns {Promise<void>}
  */
-export async function cleanJavaDescriptors() {
-  await rimraf(javaDescriptorPath);
-  await mkdirp(javaDescriptorPath);
+async function cleanJavaDescriptors() {
+  await fs.rm(javaDescriptorPath, { recursive: true, force: true });
+  await fs.mkdir(javaDescriptorPath, { recursive: true });
 }
 
 /**
@@ -666,7 +669,7 @@ function stripPlural(name) {
  * @param {boolean} [asField] 
  * @returns {JavaTypeDescriptor}
  */
-export function T_Array(itemType, asField = false) {
+function T_Array(itemType, asField = false) {
   return {
     type: "JSONArray",
     value: `JSONArray`,
@@ -720,7 +723,7 @@ export function T_Array(itemType, asField = false) {
  * @param {boolean} [asField] 
  * @returns {JavaTypeDescriptor}
  */
-export function T_Map(keyType, valueType, asField = false) {
+function T_Map(keyType, valueType, asField = false) {
   return {
     type: "JSONObject",
     value: `JSONObject`,
@@ -775,7 +778,7 @@ export function T_Map(keyType, valueType, asField = false) {
  * @param {(string | AnnotationAsParameter)[]} constants
  * @returns {JavaTypeDescriptor} 
  */
-export function T_Enum(className, typeDoc, asField, ...constants) {
+function T_Enum(className, typeDoc, asField, ...constants) {
   const code = createEnum(className, typeDoc, ...constants);
   const file = join(javaDescriptorPath, className + ".java");
   fs.writeFile(file, code, { encoding: "latin1" }).then(() => console.log("Wrote", file));
@@ -794,7 +797,7 @@ export function T_Enum(className, typeDoc, asField, ...constants) {
  * @param {boolean} [asField] 
  * @returns {JavaTypeDescriptor} 
  */
-export function T_Class(clazz, fields, classDoc, asField = false) {
+function T_Class(clazz, fields, classDoc, asField = false) {
   const code = createClass(clazz, fields, classDoc);
   const file = join(javaDescriptorPath, clazz + ".java");
   fs.writeFile(file, code, { encoding: "latin1" }).then(() => console.log("Wrote", file));
@@ -810,7 +813,7 @@ export function T_Class(clazz, fields, classDoc, asField = false) {
  * @param {boolean} [asField] 
  * @returns {JavaTypeDescriptor}
  */
-export function T_Boolean(asField = false) {
+function T_Boolean(asField = false) {
   return {
     type: "class",
     value: "Boolean",
@@ -823,7 +826,7 @@ export function T_Boolean(asField = false) {
  * @param {boolean} [asField] 
  * @returns {JavaTypeDescriptor}
  */
-export function T_String(asField = false) {
+function T_String(asField = false) {
   return {
     type: "class",
     value: "String",
@@ -836,7 +839,7 @@ export function T_String(asField = false) {
  * @param {boolean} [asField] 
  * @returns {JavaTypeDescriptor}
  */
-export function T_Number(asField = false) {
+function T_Number(asField = false) {
   return {
     type: "class",
     value: "Number",
@@ -849,7 +852,7 @@ export function T_Number(asField = false) {
  * @param {boolean} [asField] 
  * @returns {JavaTypeDescriptor}
  */
-export function T_CssSize(asField = false) {
+function T_CssSize(asField = false) {
   /** @type {DocComment} */
   const docComment = {
     deprecatedNotice: undefined,
@@ -873,7 +876,7 @@ export function T_CssSize(asField = false) {
  * @param {boolean} [asField] 
  * @returns {JavaTypeDescriptor}
  */
-export function T_BooleanOrString(asField = false) {
+function T_BooleanOrString(asField = false) {
   /** @type {DocComment} */
   const docComment = {
     deprecatedNotice: undefined,
@@ -902,7 +905,7 @@ export function T_BooleanOrString(asField = false) {
  * @param {(string | AnnotationAsParameter)[]} constants
  * @returns {JavaTypeDescriptor}
  */
-export function T_BooleanOrEnum(className, typeDoc, asField, ...constants) {
+function T_BooleanOrEnum(className, typeDoc, asField, ...constants) {
   /** @type {DocComment} */
   const docComment = {
     deprecatedNotice: undefined,
@@ -930,4 +933,20 @@ export function T_BooleanOrEnum(className, typeDoc, asField, ...constants) {
       return setterBoolean + "\n\n" + setterEnum;
     },
   };
+};
+
+module.exports = {
+  cleanJavaDescriptors,
+  Deprecated,
+  Doc,
+  T_Array,
+  T_Boolean,
+  T_BooleanOrEnum,
+  T_BooleanOrString,
+  T_Class,
+  T_CssSize,
+  T_Enum,
+  T_Map,
+  T_Number,
+  T_String,
 };

--- a/monacoeditor/pom.xml
+++ b/monacoeditor/pom.xml
@@ -64,25 +64,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <!-- Make generated Java files available -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>include-generated-sources</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${project.basedir}/target/generated-sources/java/</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Minify monaco editor sources -->
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -142,17 +123,6 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <arguments>run generate-extras</arguments>
-                        </configuration>
-                    </execution>
-                    <!-- Generate editor options -->
-                    <execution>
-                        <id>generate editor options</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <arguments>run generate-editor-options</arguments>
                         </configuration>
                     </execution>
                     <!-- Run build -->

--- a/monacoeditor/src/main/js/package.json
+++ b/monacoeditor/src/main/js/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "verify": "tsc --project jsconfig.json --noEmit",
     "generate-locales": "node src/scripts/generateLocales.js",
-    "generate-extras": "node src/scripts/generateExtras.js",
-    "generate-editor-options": "node src/scripts/generateEditorOptions.js"
+    "generate-extras": "node src/scripts/generateExtras.js"
   },
   "author": "Andre Wachsmuth",
   "license": "MIT",


### PR DESCRIPTION
Fix #718

As mentioned in #718, I moved the editor options Java class files from the `org.primefaces.extensions:resources-monacoeditor` module to `org.primefaces.extensions:primefaces-extensions`. The resources module now has no Java class files anymore, all required classes are in the core module. This should hopefully fix the issue with Payara scanning the classes and not finding the super classes.

If anybody made a Maven module that declares only `resources-monacoeditor` as a dependency and imported the Java classes, this would be a breaking change, but I don't see any reason why anybody would do that. As long as they also depend on `primefaces-extensions`, the classes are all in the same package and everything should keep working.