### PR TITLE
Fix enum name for monaco editor settings

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/scripts/generateEditorOptions.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/scripts/generateEditorOptions.js
@@ -917,7 +917,7 @@ async function main() {
         ),
 
         [Doc()]: "Enable experimental whitespace rendering. Defaults to {@code svg}.",
-        experimentalWhitespaceRendering: T_Enum("EFoldingStrategy",
+        experimentalWhitespaceRendering: T_Enum("EExperimentalWhitespaceRendering",
             "Enable experimental whitespace rendering. Defaults to {@code svg}.",
             false,
             "off", "svg", "font"


### PR DESCRIPTION
An enum name was used twice, which is definitely wrong and may have resulted in build errors for some people.

I couldn't reproduce it, but perhaps that's why it sometimes failed for Jasper?