### PR TITLE
clockpicker: 12-hour format implementation

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/clockpicker/ClockPicker.java
+++ b/core/src/main/java/org/primefaces/extensions/component/clockpicker/ClockPicker.java
@@ -47,7 +47,8 @@ public class ClockPicker extends AbstractPrimeHtmlInputText implements Widget, I
         placement,
         align,
         autoclose,
-        vibrate;
+        vibrate,
+        twelvehour;
     }
     
     public ClockPicker() {
@@ -117,6 +118,14 @@ public class ClockPicker extends AbstractPrimeHtmlInputText implements Widget, I
     
     public void setVibrate(final Boolean vibrate) {
         getStateHelper().put(PropertyKeys.vibrate, vibrate);
+    }
+    
+    public Boolean getTwelvehour() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.twelvehour, false); 
+    }
+    
+    public void setTwelvehour(final Boolean twelvehour) {
+        getStateHelper().put(PropertyKeys.twelvehour, twelvehour);
     }
 
 }

--- a/core/src/main/java/org/primefaces/extensions/component/clockpicker/ClockPickerRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/clockpicker/ClockPickerRenderer.java
@@ -24,6 +24,7 @@ package org.primefaces.extensions.component.clockpicker;
 import java.io.IOException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Objects;
 
 import javax.el.ValueExpression;
@@ -40,7 +41,11 @@ import org.primefaces.util.WidgetBuilder;
 
 public class ClockPickerRenderer extends InputRenderer {
 
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    private static final DateTimeFormatter FORMATTER_24_HOUR = DateTimeFormatter.ofPattern("HH:mm");
+    // Note: We specify Locale.ENGLISH in the DateTimeFormatter to ensure consistent formatting, especially when interfacing with clockpicker.js.
+    // The JavaScript library generates time in the AM/PM format based on English conventions.
+    // Without this specification, different locales might cause errors during conversion, as clockpicker.js relies on the English-style AM/PM markers.
+    private static final DateTimeFormatter FORMATTER_12_HOUR = DateTimeFormatter.ofPattern("hh:mma").withLocale(Locale.ENGLISH);
 
     @Override
     public void decode(FacesContext context, UIComponent component) {
@@ -111,6 +116,7 @@ public class ClockPickerRenderer extends InputRenderer {
         wb.attr("align", clockPicker.getAlign(), "left");
         wb.attr("autoclose", clockPicker.getAutoclose(), false);
         wb.attr("vibrate", clockPicker.getVibrate(), true);
+        wb.attr("twelvehour", clockPicker.getTwelvehour(), false);
 
         encodeClientBehaviors(context, clockPicker);
         wb.finish();
@@ -132,7 +138,7 @@ public class ClockPickerRenderer extends InputRenderer {
                 return clockPicker.getConverter().getAsString(context, clockPicker, value);
             }
             else if (value instanceof LocalTime) {
-                return FORMATTER.format((LocalTime) value);
+                return clockPicker.getTwelvehour() ? ((LocalTime) value).format(FORMATTER_12_HOUR) : ((LocalTime) value).format(FORMATTER_24_HOUR);
             }
         }
         catch (Exception e) {
@@ -168,9 +174,10 @@ public class ClockPickerRenderer extends InputRenderer {
             ValueExpression ve = clockPicker.getValueExpression("value");
             if (ve != null) {
                 Class<?> type = ve.getType(context.getELContext());
-                if (type != null && type != Object.class && type.isAssignableFrom(LocalTime.class)) {
+                if (type != null && submittedValue != null && type.isAssignableFrom(LocalTime.class)) {
                     // Use built-in converter for LocalTime
-                    return LocalTime.parse(submittedValue, FORMATTER);
+                    return clockPicker.getTwelvehour() ? LocalTime.parse(submittedValue, FORMATTER_12_HOUR)
+                                : LocalTime.parse(submittedValue, FORMATTER_24_HOUR);
                 }
             }
         }

--- a/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -10926,6 +10926,12 @@ See showcase for an example. Default null.]]>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description><![CDATA[enables twelve hour mode with AM & PM buttons. Default is false]]></description>
+            <name>twelvehour</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
 
 </facelet-taglib>

--- a/showcase/src/main/webapp/sections/clockpicker/example-basicUsage.xhtml
+++ b/showcase/src/main/webapp/sections/clockpicker/example-basicUsage.xhtml
@@ -10,6 +10,7 @@
     <h:panelGroup id="timePickerGroup" layout="block">
         <p>Auto-Close Mode</p>
         <pe:clockpicker id="autoclose" autoclose="true" value="#{clockPickerController.time}"
+        					twelvehour="true"
                             widgetVar="autocloseWidget" />
 
 


### PR DESCRIPTION
![image](https://github.com/primefaces-extensions/primefaces-extensions/assets/10467831/57b946b2-8aed-4134-85f6-5545a84e629a)

The conversion of AM/PM from datepicker JS to component requires Locale.ENGLISH since different locale might generate different style of writing am pm.

For example, https://www.chicagomanualofstyle.org/qanda/data/faq/topics/Abbreviations/faq0095.html#:~:text=There%20are%20six%20ways%20to,periods%3A%2010%20A.M.%2C%2010%20P.M.&text=Small%20caps%20with%20periods%3A%2010,M.%2C%2010%20P.

![image](https://github.com/primefaces-extensions/primefaces-extensions/assets/10467831/122f01b3-3088-44c5-bd00-1a0cd446fb45)


clockpicker js generates `xx:xxAM` or `xx:xxPM`. As I mentioned in the code

```
// Note: We specify Locale.ENGLISH in the DateTimeFormatter to ensure consistent formatting, especially when interfacing with clockpicker.js.
    // The JavaScript library generates time in the AM/PM format based on English conventions.
    // Without this specification, different locales might cause errors during conversion, as clockpicker.js relies on the English-style AM/PM markers.
```