### PR TITLE
InputPhone: wrap input event

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/inputphone/inputphone-widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/inputphone/inputphone-widget.js
@@ -67,8 +67,23 @@ PrimeFaces.widget.ExtInputPhone = PrimeFaces.widget.BaseWidget.extend({
                 $this.callBehavior('countrySelect', ext);
             }
         });
-        this.input.addEventListener('input', function () {
+
+        // get the current attached events if using CSP
+        let events = this.inputJq[0] ? $._data(this.inputJq[0], "events") : null;
+
+        // use DOM if non-CSP and JQ event if CSP
+        let originalOninput = this.inputJq.prop('oninput');
+        if (!originalOninput && events && events.input) {
+            originalOninput = events.input[0].handler;
+        }
+
+        this.inputJq.prop('oninput', null).off('input').on('input', function (e) {
+            let oldVal = $this.inputHiddenJq.val();
             $this.inputHiddenJq.val($this.getNumber());
+            if (originalOninput && originalOninput.call(this, e) === false) {
+                $this.inputHiddenJq.val(oldVal);
+                return false;
+            }
         });
     },
 


### PR DESCRIPTION
Without wrapping, this is what happens with a `p:ajax event="input"`
![inputhphonr](https://github.com/primefaces-extensions/primefaces-extensions/assets/18428155/f107926c-f1e9-4ff3-8b5b-bf8ec3623183)
(submitted value is one step behind)