### PR TITLE
Prevents a TypeError from being thrown.

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/sheet/1-sheet.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/sheet/1-sheet.js
@@ -92,6 +92,9 @@ PrimeFaces.widget.ExtSheet = PrimeFaces.widget.DeferredWidget.extend({
             },
             cells: function (row, col, prop) {
                 var cp = {};
+                if (col < 0) {
+                    return cp;
+                }
                 var column = $this.cfg.columns[col];
                 if (column.type === 'password') {
                     cp.renderer = this.passwordCellRenderer;


### PR DESCRIPTION
A TypeError is being thrown after setting `autoRowSize: true` using the `updateSettings` function:
```javascript
$hot.updateSettings({
    autoRowSize: true,
});
```
The `col` parameter ends up being `-1` causing this error to be thrown in the browser console:
```
sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:2092  Uncaught TypeError: Cannot read properties of undefined (reading 'type')
    at m.cells (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:2092:60)
    at h.default.getCellMeta (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:395:129)
    at h.default._getColWidthFromSettings (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:401:139)
    at getColWidth (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:401:392)
    at f.value (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:575:311)
    at f.value (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:575:462)
    at e.value (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:428:168)
    at e.value (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:424:217)
    at e.value (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:421:303)
    at G.value (sheet.js.xhtml?ln=primefaces-extensions&v=13.0.8&e=13.0.8:1282:335)
```