### PR TITLE
Fix #1639: SunEditor do not escape value

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/suneditor/SunEditorRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/suneditor/SunEditorRenderer.java
@@ -91,7 +91,8 @@ public class SunEditorRenderer extends InputRenderer {
 
         String valueToRender = editor.sanitizeHtml(context, ComponentUtils.getValueToRender(context, editor));
         if (valueToRender != null) {
-            writer.write(valueToRender);
+            // #1639 do not escape as its already been sanitized above, and we want to keep exact formatting
+            writer.writeText(valueToRender, "value");
         }
 
         writer.endElement("textarea");


### PR DESCRIPTION
Fix #1639: SunEditor do not escape value

I looked at what PF InputTextArea is doing and it does not escape the output.