### PR TITLE
Update monaco-editor to 0.51.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "npm"
+    directory: "/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
     directory: "/monacoeditor"
     schedule:
       interval: "daily"

--- a/core/src/main/java/org/primefaces/extensions/component/monacoeditor/BaseEditorPropertyKeys.java
+++ b/core/src/main/java/org/primefaces/extensions/component/monacoeditor/BaseEditorPropertyKeys.java
@@ -38,6 +38,7 @@ enum BaseEditorPropertyKeys {
     language, //
     oninitialized, //
     onpaste, //
+    placeholder, //
     scheme, //
     locale, //
     localeUrl, //

--- a/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoEditorCommon.java
+++ b/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoEditorCommon.java
@@ -50,6 +50,7 @@ public abstract class MonacoEditorCommon<TEditorOpts> extends HtmlInputTextarea
     static final String DEFAULT_EXTENSION = "";
     static final String DEFAULT_HEIGHT = "600px";
     static final String DEFAULT_LANGUAGE = "plaintext";
+    static final String DEFAULT_PLACEHOLDER = "";
     static final boolean DEFAULT_READONLY = false;
     static final String DEFAULT_SCHEME = "inmemory";
     static final String DEFAULT_TABINDEX = null;
@@ -112,6 +113,10 @@ public abstract class MonacoEditorCommon<TEditorOpts> extends HtmlInputTextarea
         return (String) getStateHelper().eval(BaseEditorPropertyKeys.onpaste, null);
     }
 
+    public final String getPlaceholder() {
+        return (String) getStateHelper().eval(BaseEditorPropertyKeys.placeholder, null);
+    }
+
     public final String getScheme() {
         return (String) getStateHelper().eval(BaseEditorPropertyKeys.scheme, DEFAULT_SCHEME);
     }
@@ -171,6 +176,10 @@ public abstract class MonacoEditorCommon<TEditorOpts> extends HtmlInputTextarea
 
     public final void setOnpaste(final String onpaste) {
         getStateHelper().put(BaseEditorPropertyKeys.onpaste, onpaste);
+    }
+
+    public final void setPlaceholder(final String placeholder) {
+        getStateHelper().put(BaseEditorPropertyKeys.placeholder, placeholder);
     }
 
     public final void setScheme(final String scheme) {

--- a/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoEditorCommonRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoEditorCommonRenderer.java
@@ -139,6 +139,7 @@ abstract class MonacoEditorCommonRenderer<TEditor extends MonacoEditorCommon<TEd
         wb.attr("locale", monacoEditor.calculateLocale().toString());
         wb.attr("localeUrl", monacoEditor.getLocaleUrl());
         wb.attr("readonly", monacoEditor.isReadonly(), MonacoEditorCommon.DEFAULT_READONLY);
+        wb.attr("placeholder", monacoEditor.getPlaceholder(), MonacoEditorCommon.DEFAULT_PLACEHOLDER);
         wb.attr("scheme", monacoEditor.getScheme(), MonacoEditorCommon.DEFAULT_SCHEME);
         wb.attr("tabIndex", monacoEditor.getTabindex(), MonacoEditorCommon.DEFAULT_TABINDEX);
         wb.attr("height", monacoEditor.getHeight(), MonacoEditorCommon.DEFAULT_HEIGHT);

--- a/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -1156,6 +1156,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Sets a placeholder for the editor. If set, the placeholder is shown if the editor is empty.]]>
+            </description>
+            <name>placeholder</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Defines if the modified editor is readonly. This option makes the UI not editable, but still
                 accepts values that are submitted (e.g. when the editor value was changed via JavaScript). Use
                 <code>disabled</code> if submitted values should not be accepted.]]>
@@ -1790,6 +1798,14 @@
             <name>converter</name>
             <required>false</required>
             <type>javax.faces.convert.Converter</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Sets a placeholder for the editor. If set, the placeholder is shown if the editor is empty.]]>
+            </description>
+            <name>placeholder</name>
+            <required>false</required>
+            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>

--- a/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -347,6 +347,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Sets a placeholder for the editor. If set, the placeholder is shown if the editor is empty.]]>
+            </description>
+            <name>placeholder</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[The tab index to assign to the editor. If not given, no tab index will be assigned.]]>
             </description>
             <name>tabindex</name>
@@ -745,6 +753,14 @@
             <name>disabled</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Sets a placeholder for the editor. If set, the placeholder is shown if the editor is empty.]]>
+            </description>
+            <name>placeholder</name>
+            <required>false</required>
+            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/01-monaco-helper.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/01-monaco-helper.js
@@ -328,7 +328,6 @@ window.monacoModule.helper = (function () {
         : undefined
     });
 
-
     // XHTML attribute takes precedence over the editor options
     const originalDisabled = opts.originalDisabled !== undefined
       ? opts.originalDisabled
@@ -339,6 +338,7 @@ window.monacoModule.helper = (function () {
     const baseEditorOptions = {
       domReadOnly: opts.readonly || opts.disabled,
       readOnly: opts.readonly || opts.disabled,
+      placeholder: opts.placeholder,
       originalEditable: !originalDisabled && !originalReadonly,
     };
 
@@ -406,6 +406,7 @@ window.monacoModule.helper = (function () {
     const baseEditorOptions = {
       domReadOnly: defaultIfNullish(opts.readonly, false) || defaultIfNullish(opts.disabled, false),
       model: model,
+      placeholder: opts.placeholder,
       readOnly: defaultIfNullish(opts.readonly, false) || defaultIfNullish(opts.disabled, false),
     };
     const editorOptions = assign(baseEditorOptions, incomingEditorOptions);
@@ -568,7 +569,7 @@ window.monacoModule.helper = (function () {
 
   /**
    * @template {import("monaco-editor").editor.IEditor} TEditor
-   * @template {PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>} K
+   * @template {PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>} K
    * @param {K} method
    * @param {TEditor} editor
    * @param {PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>} args
@@ -584,7 +585,7 @@ window.monacoModule.helper = (function () {
         return await fn.apply(editor, args);
       }
       else {
-        throw new Error(`Method ${method} does not exist on the editor.`);
+        throw new Error(`Method ${String(method)} does not exist on the editor.`);
       }
     }
     else {
@@ -682,6 +683,7 @@ window.monacoModule.helper = (function () {
     extender: undefined,
     extension: "",
     language: "plaintext",
+    placeholder: "",
     scheme: "inmemory",
     tabIndex: undefined,
     readonly: false,

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/03-monaco-widget-base.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/03-monaco-widget-base.js
@@ -129,7 +129,7 @@ window.monacoModule = window.monacoModule || {};
     setValue(value) { throw new Error("Must override abstract method."); }
 
     /**
-     * @template {PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>} K
+     * @template {PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>} K
      * @param {K} method
      * @param {PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>} args
      * @returns {Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<TEditor[K]>>>}

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-iframe-controller.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-iframe-controller.js
@@ -68,7 +68,7 @@ window.monacoModule = window.monacoModule || {};
      * @param {Partial<TExtender>} extender 
      */
     constructor(extender) {
-      if (window.MonacoEnvironment.InstanceId === undefined) {
+      if (window.MonacoEnvironment?.InstanceId === undefined) {
         throw new Error("IllegalState: No MonacoEnvironment.InstanceId available");
       }
 
@@ -231,7 +231,7 @@ window.monacoModule = window.monacoModule || {};
     }
 
     /**
-     * @template {PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>} K
+     * @template {PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>} K
      * @param {K} method
      * @param {PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>} args
      * @returns {Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<TEditor[K]>>>}

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-widget-framed.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-widget-framed.js
@@ -99,7 +99,7 @@ window.monacoModule = window.monacoModule || {};
     }
 
     /**
-     * @template {PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>} K
+     * @template {PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>} K
      * @param {K} method
      * @param {PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>} args
      * @returns {Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<TEditor[K]>>>}
@@ -198,7 +198,7 @@ window.monacoModule = window.monacoModule || {};
 
     /**
      * @protected
-     * @template {PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>} K
+     * @template {PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>} K
      * @param {K} method
      * @param {PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>} args
      * @returns {Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<TEditor[K]>>>}
@@ -548,7 +548,7 @@ window.monacoModule = window.monacoModule || {};
 
     /**
      * @protected
-     * @template {PrimeFaces.MatchingKeys<import("monaco-editor").editor.IStandaloneCodeEditor, (...args: never[]) => unknown>} K
+     * @template {PrimeFaces.KeysMatchingCondition<import("monaco-editor").editor.IStandaloneCodeEditor, (...args: never[]) => unknown>} K
      * @param {K} method
      * @param {PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<import("monaco-editor").editor.IStandaloneCodeEditor[K]>} args
      * @returns {Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<import("monaco-editor").editor.IStandaloneCodeEditor[K]>>>}
@@ -695,7 +695,7 @@ window.monacoModule = window.monacoModule || {};
 
     /**
      * @protected
-     * @template {PrimeFaces.MatchingKeys<import("monaco-editor").editor.IStandaloneDiffEditor, (...args: never[]) => unknown>} K
+     * @template {PrimeFaces.KeysMatchingCondition<import("monaco-editor").editor.IStandaloneDiffEditor, (...args: never[]) => unknown>} K
      * @param {K} method
      * @param {PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<import("monaco-editor").editor.IStandaloneDiffEditor[K]>} args
      * @returns {Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<import("monaco-editor").editor.IStandaloneDiffEditor[K]>>>}

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-widget-inline.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/04-monaco-widget-inline.js
@@ -191,7 +191,7 @@ window.monacoModule = window.monacoModule || {};
     }
 
     /**
-     * @template {PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>} K
+     * @template {PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>} K
      * @param {K} method
      * @param {PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>} args
      * @returns {Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<TEditor[K]>>>}

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/internal.d.ts
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/internal.d.ts
@@ -120,7 +120,7 @@ interface Helper {
   globalEval: (script: string, nonce?: string) => void;
   invokeMonaco: <
     TEditor extends import("monaco-editor").editor.IEditor,
-    K extends PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>
+    K extends PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>
     >(
     editor: TEditor,
     method: K,
@@ -246,10 +246,10 @@ type ResponseMessageData =
 
 type InvokeMonacoMessageData<
   TEditor extends import("monaco-editor").editor.IEditor,
-  K extends PrimeFaces.MatchingKeys<
+  K extends PrimeFaces.KeysMatchingCondition<
     TEditor,
     (...args: never[]) => unknown
-  > = PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>
+  > = PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>
   > = {
     args: PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>;
     messageId: number;

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package-lock.json
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package-lock.json
@@ -8,10 +8,10 @@
         "primefaces": "^14.0.0"
       },
       "devDependencies": {
-        "@types/jquery": "^3.5.6",
-        "@types/node": "^20.10.6",
-        "monaco-editor": "^0.31.0",
-        "typescript": "^4.5.5"
+        "@types/jquery": "^3.5.30",
+        "@types/node": "^20.14.8",
+        "monaco-editor": "^0.51.0",
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -127,9 +127,9 @@
       "integrity": "sha512-uojbVPWzBQ/n/0jc/d16fLqmGasFIptbrLD2WrCPWArlk+5PgblOqH4EDkI3AoobXLAlOK5yF01V8jMmvMG5qg=="
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
-      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.30.tgz",
+      "integrity": "sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==",
       "dependencies": {
         "@types/sizzle": "*"
       }
@@ -148,12 +148,12 @@
       "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "version": "20.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.1.tgz",
+      "integrity": "sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/quill": {
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.0.tgz",
-      "integrity": "sha512-H3QmysEwxxY8oxmFhIFcY9JkuwilUDa6txdAxb797cVr7XFZX27a3SDwcGJmTlV9iGPwdh132r3KKCS5aNL4Gg==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.51.0.tgz",
+      "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw==",
       "dev": true
     },
     "node_modules/parchment": {
@@ -336,22 +336,22 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
     "node_modules/uuid": {
@@ -540,9 +540,9 @@
       "integrity": "sha512-uojbVPWzBQ/n/0jc/d16fLqmGasFIptbrLD2WrCPWArlk+5PgblOqH4EDkI3AoobXLAlOK5yF01V8jMmvMG5qg=="
     },
     "@types/jquery": {
-      "version": "3.5.29",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
-      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.30.tgz",
+      "integrity": "sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==",
       "requires": {
         "@types/sizzle": "*"
       }
@@ -561,12 +561,12 @@
       "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="
     },
     "@types/node": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "version": "20.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.1.tgz",
+      "integrity": "sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==",
       "dev": true,
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "@types/quill": {
@@ -638,9 +638,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.0.tgz",
-      "integrity": "sha512-H3QmysEwxxY8oxmFhIFcY9JkuwilUDa6txdAxb797cVr7XFZX27a3SDwcGJmTlV9iGPwdh132r3KKCS5aNL4Gg==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.51.0.tgz",
+      "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw==",
       "dev": true
     },
     "parchment": {
@@ -706,15 +706,15 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
     "uuid": {

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package.json
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package.json
@@ -1,9 +1,9 @@
 {
   "devDependencies": {
-    "@types/jquery": "^3.5.6",
-    "@types/node": "^20.10.6",
-    "monaco-editor": "^0.31.0",
-    "typescript": "^4.5.5"
+    "@types/jquery": "^3.5.30",
+    "@types/node": "^20.14.8",
+    "monaco-editor": "^0.51.0",
+    "typescript": "^5.5.4"
   },
   "scripts": {
     "verify": "tsc --noEmit",

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/primefaces-monaco-global.d.ts
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/primefaces-monaco-global.d.ts
@@ -22,12 +22,16 @@ interface Window {
   /**
    * Monaco editor environment, which contains the locale and some factory functions.
    */
-  MonacoEnvironment: import("monaco-editor").Environment;
+  MonacoEnvironment?: import("monaco-editor").Environment | undefined;
 }
 
 // === Monaco editor widget
 
 declare namespace PrimeFaces {
+  type KeysMatchingCondition<Base, Condition> = Exclude<{
+    [Key in keyof Base]: Base[Key] extends Condition ? Key : never;
+  }[keyof Base], undefined>;
+  
   namespace widget {
     namespace ExtMonacoEditor {
       // === General helper types
@@ -100,7 +104,7 @@ declare namespace PrimeFaces {
          * @returns A promise that resolves with the value returned by the given method. The promise is rejected when
          * the editor is not ready yet.
          */
-        invokeMonaco<K extends PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>>(
+        invokeMonaco<K extends PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>>(
           method: K, ...args: PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>
         ): Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<TEditor[K]>>>;
 
@@ -642,6 +646,11 @@ declare namespace PrimeFaces {
       locale: string;
 
       /**
+       * Sets a placeholder for the editor. If set, the placeholder is shown if the editor is empty.
+       */
+      placeholder: string;
+
+      /**
        * Whether the editor is read-only.
        */
       readonly: boolean;
@@ -882,7 +891,7 @@ declare namespace PrimeFaces {
       getWidgetId(): string;
       getWidgetOptions(): PartialWidgetCfg<TCfg>;
       getValue(): Promise<string>;
-      invokeMonaco<K extends PrimeFaces.MatchingKeys<TEditor, (...args: never[]) => unknown>>(
+      invokeMonaco<K extends PrimeFaces.KeysMatchingCondition<TEditor, (...args: never[]) => unknown>>(
         method: K, ...args: PrimeFaces.widget.ExtMonacoEditor.ParametersIfFn<TEditor[K]>
       ): Promise<Awaited<PrimeFaces.widget.ExtMonacoEditor.ReturnTypeIfFn<TEditor[K]>>>;
       invokeMonacoScript<TRetVal, TArgs extends any[]>(script: string | ((editor: TEditor, ...args: TArgs) => TRetVal), ...args: TArgs): Promise<Awaited<TRetVal>>;

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/scripts/generateEditorOptions.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/scripts/generateEditorOptions.js
@@ -103,12 +103,14 @@ async function main() {
         alternativeDefinitionCommand: T_String(),
         alternativeImplementationCommand: T_String(),
         alternativeReferenceCommand: T_String(),
+        alternativeTestsCommand: T_String(),
         alternativeTypeDefinitionCommand: T_String(),
         multiple: EGoToLocationValues,
         multipleDeclarations: EGoToLocationValues,
         multipleDefinitions: EGoToLocationValues,
         multipleImplementations: EGoToLocationValues,
         multipleReferences: EGoToLocationValues,
+        multipleTests: EGoToLocationValues,
         multipleTypeDefinitions: EGoToLocationValues,
     }, "Configuration options for go to location");
 
@@ -142,6 +144,23 @@ async function main() {
 
         [Doc()]: "Enables the padding around the inlay hint. Defaults to {@code false}.",
         padding: T_Boolean(),
+    }, "Control the behavior and rendering of the inline hints.");
+
+    const EditorInlineEditOptions = T_Class("EditorInlineEditOptions", {
+        [Doc()]: "Enable or disable the rendering of automatic inline edit.",
+        enabled: T_Boolean(),
+
+        [Doc()]: "Font family for inline suggestions.",
+        fontFamily: T_String(),
+
+        [Doc()]: "Does not clear active inline suggestions when the editor loses focus.",
+        keepOnBlur: T_Boolean(),
+
+        showToolbar: T_Enum("EInlineEditorShowToolbarMode",
+            "Whether to show the toolbar for inline suggestions.",
+            false,
+            "always", "never", "onHover"
+        ),
     }, "Control the behavior and rendering of the inline hints.");
 
     const EditorInlineSuggestOptions = T_Class("EditorInlineSuggestOptions", {
@@ -474,6 +493,13 @@ async function main() {
         width: T_Number(),
     }, "The initial editor dimension (to avoid measuring the container).");
 
+    const EditorHideUnchangedRegions = T_Class("EditorHideUnchangedRegions", {
+        contextLineCount: T_Number(),
+        enabled: T_Boolean(),
+        minimumLineCount: T_Number(),
+        revealLineCount: T_Number(),
+    }, "Options for whether unchanged regions should be hidden or visible.");
+
     const EditorBracketPairColorizationOptions = T_Class("EditorBracketPairColorizationOptions", {
         [Doc()]: "Enable or disable bracket pair colorization.",
         enabled: T_Boolean(),
@@ -546,6 +572,9 @@ async function main() {
         [Doc()]: "The initial editor dimension (to avoid measuring the container).",
         dimension: EditorDimension,
 
+        [Doc()]: "Options for whether unchanged regions should be hidden or visible.",
+        hideUnchangedRegions: EditorHideUnchangedRegions,
+
         [Doc()]: "Controls the diff algorithm.",
         diffAlgorithm: T_Enum("EDiffAlgorithm",
             "Controls the diff algorithm.",
@@ -579,6 +608,9 @@ async function main() {
         [Doc()]: "Whether the diff editor aria label should be verbose.",
         accessibilityVerbose: T_Boolean(),
 
+        [Doc()]: "If set, the diff editor is optimized for small views. Defaults to {@code false}.",
+        compactMode: T_Boolean(),
+
         [Doc()]: "Should the diff editor enable code lens? Defaults to {@code false}.",
         diffCodeLens: T_Boolean(),
 
@@ -587,6 +619,9 @@ async function main() {
 
         [Doc()]: "Compute the diff by ignoring leading/trailing whitespace Defaults to {@code true}.",
         ignoreTrimWhitespace: T_Boolean(),
+
+        [Doc()]: "If the diff editor should only show the difference review mode.",
+        onlyShowAccessibleDiffViewer: T_Boolean(),
 
         [Doc()]: "Indicates if the gutter menu should be rendered.",
         renderGutterMenu: T_Boolean(),
@@ -603,6 +638,9 @@ async function main() {
         [Doc()]: "Render the differences in two side-by-side editors. Defaults to {@code true}.",
         renderSideBySide: T_Boolean(),
 
+        [Doc()]: "When <code>renderSideBySide</code> is enabled, <code>useInlineViewWhenSpaceIsLimited</code> is set, and the diff editor has a width less than <code>renderSideBySideInlineBreakpoint</code>, the inline view is used.",
+        useInlineViewWhenSpaceIsLimited: T_Boolean(),
+        
         [Doc()]: "Timeout in milliseconds after which diff computation is cancelled. Defaults to {@code 5000}.",
         maxComputationTime: T_Number(),
 
@@ -611,6 +649,9 @@ async function main() {
 
         [Doc()]: "When <code>renderSideBySide</code> is enabled, <code>useInlineViewWhenSpaceIsLimited</code> is set, and the diff editor has a width less than <code>renderSideBySideInlineBreakpoint</code>, the inline view is used.",
         renderSideBySideInlineBreakpoint: T_Number(),
+
+        [Doc()]: "The default ratio when rendering side-by-side editors. Must be a number between <code>0</code> and <code>1</code>, min sizes apply. Defaults to <code>0.5</code>",
+        splitViewDefaultRatio: T_Number(),
 
         [Doc()]: "Aria label for modified editor.",
         modifiedAriaLabel: T_String(),
@@ -1163,7 +1204,7 @@ async function main() {
         [Doc()]: "Copying without a selection copies the current line",
         emptySelectionClipboard: T_Boolean(),
 
-        experimentalInlineEdit: T_Boolean(),
+        experimentalInlineEdit: EditorInlineEditOptions,
 
         [Doc()]: "Display overflow widgets as {@code fixed}. Defaults to {@code false}",
         fixedOverflowWidgets: T_Boolean(),
@@ -1369,6 +1410,9 @@ async function main() {
 
         [Doc()]: "The font family",
         fontFamily: T_String(),
+
+        [Doc()]: "Sets a placeholder for the editor. If set, the placeholder is shown if the editor is empty.",
+        placeholder: T_String(),
 
         [Doc()]: "Locales used for segmenting lines into words when doing word related navigations or operations.<p>Specify the BCP 47 language tag of the word you wish to recognize (e.g., ja, zh-CN, zh-Hant-TW, etc.). Defaults to empty array",
         wordSegmenterLocales: T_Array(T_String()),

--- a/monacoeditor/src/main/js/nls-replace.js
+++ b/monacoeditor/src/main/js/nls-replace.js
@@ -2,8 +2,12 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+// eslint-disable-next-line local/code-import-patterns
+import { getNLSLanguage, getNLSMessages } from "./node_modules/monaco-editor-mod/esm/vs/nls.messages.js";
+// eslint-disable-next-line local/code-import-patterns
+export { getNLSLanguage, getNLSMessages } from "./node_modules/monaco-editor-mod/esm/vs/nls.messages.js";
 const globalScope = typeof globalThis === "object" ? globalThis : typeof window === "object" ? window : typeof self === "object" ? self : global; 
-let isPseudo = (typeof document !== 'undefined' && document.location && document.location.hash.indexOf('pseudo=true') >= 0);
+const isPseudo = getNLSLanguage() === 'pseudo' || (typeof document !== 'undefined' && document.location && document.location.hash.indexOf('pseudo=true') >= 0);
 const DEFAULT_TAG = 'i-default';
 function _format(message, args) {
     let result;

--- a/monacoeditor/src/main/js/package-lock.json
+++ b/monacoeditor/src/main/js/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "insane": "^2.6.2",
-        "monaco-editor": "^0.50.0"
+        "monaco-editor": "^0.51.0"
       },
       "devDependencies": {
         "@types/cross-spawn": "^6.0.6",
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
-      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA=="
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.51.0.tgz",
+      "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -2935,9 +2935,9 @@
       "dev": true
     },
     "monaco-editor": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
-      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA=="
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.51.0.tgz",
+      "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw=="
     },
     "nanoid": {
       "version": "3.3.7",

--- a/monacoeditor/src/main/js/package.json
+++ b/monacoeditor/src/main/js/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "cross-spawn": "^7.0.3",
     "insane": "^2.6.2",
-    "monaco-editor": "^0.50.0"
+    "monaco-editor": "^0.51.0"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",

--- a/monacoeditor/src/main/js/package.json
+++ b/monacoeditor/src/main/js/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "verify": "tsc --project jsconfig.json --noEmit",
     "generate-locales": "node src/scripts/generateLocales.js",
-    "generate-extras": "node src/scripts/generateExtras.js"
+    "generate-extras": "node src/scripts/generateExtras.js",
+    "webpack": "webpack --env production"
   },
   "author": "Andre Wachsmuth",
   "license": "MIT",

--- a/showcase/src/main/webapp/sections/monacoEditor/example-basicUsage.xhtml
+++ b/showcase/src/main/webapp/sections/monacoEditor/example-basicUsage.xhtml
@@ -111,6 +111,7 @@
         disabled="#{monacoEditorController.disabled}"
         readonly="#{monacoEditorController.readOnly}"
         locale="#{monacoEditorController.locale}"
+        placeholder="enter your code... (inline)"
         editorOptions="#{monacoEditorController.editorOptions}"
         width="100%" height="400px" autoResize="true" />
 
@@ -121,6 +122,7 @@
         disabled="#{monacoEditorController.disabledFramed}"
         readonly="#{monacoEditorController.readOnlyFramed}"
         locale="#{monacoEditorController.localeFramed}"
+        placeholder="enter your code... (framed)"
         editorOptions="#{monacoEditorController.editorOptionsFramed}"
         width="100%" height="400px" autoResize="true" />
 

--- a/showcase/src/main/webapp/sections/monacoEditor/example-basicUsageDiff.xhtml
+++ b/showcase/src/main/webapp/sections/monacoEditor/example-basicUsageDiff.xhtml
@@ -160,6 +160,7 @@
         originalReadonly="#{monacoEditorController.originalReadOnly}"
         language="#{monacoEditorController.language}"
         locale="#{monacoEditorController.locale}"
+        placeholder="enter your code... (inline)"
         width="100%" height="400px" autoResize="true" />
 
     <pe:monacoDiffEditorFramed id="monacoEditorFramed" widgetVar="monacoEditorFramed"
@@ -174,6 +175,7 @@
         originalReadonly="#{monacoEditorController.originalReadOnlyFramed}"
         language="#{monacoEditorController.languageFramed}"
         locale="#{monacoEditorController.localeFramed}"
+        placeholder="enter your code... (framed)"
         width="100%" height="400px" autoResize="true" />
 
     <p:commandButton id="btnSubmit" value="Submit" icon="pi pi-save"


### PR DESCRIPTION
Closes primefaces-extensions/primefaces-extensions#1655

* Fix localization
* Add `placeholder` attribute to `pe:monacoEditor`, `pe:monacoEditorFramed`, `pe:monacoDiffEditor`, `pe:monacoDiffEditorFramed` components
* Add new options to Java wrapper
* Add `/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor` to `dependabot.yml`. It also contains a `package.json` that still had `0.31` of monaco-editor