### PR TITLE
Fix #1771: Sheet CSS remove legacy styles no longer needed

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/sheet/0-handsontable.full.css
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/sheet/0-handsontable.full.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*!
  * (The MIT License)
  * 
@@ -79,9 +80,9 @@
 .col-lg-1.handsontable, .col-lg-10.handsontable, .col-lg-11.handsontable, .col-lg-12.handsontable,
 .col-lg-2.handsontable, .col-lg-3.handsontable, .col-lg-4.handsontable, .col-lg-5.handsontable, .col-lg-6.handsontable, .col-lg-7.handsontable, .col-lg-8.handsontable, .col-lg-9.handsontable,
 .col-md-1.handsontable, .col-md-10.handsontable, .col-md-11.handsontable, .col-md-12.handsontable,
-.col-md-2.handsontable, .col-md-3.handsontable, .col-md-4.handsontable, .col-md-5.handsontable, .col-md-6.handsontable, .col-md-7.handsontable, .col-md-8.handsontable, .col-md-9.handsontable
+.col-md-2.handsontable, .col-md-3.handsontable, .col-md-4.handsontable, .col-md-5.handsontable, .col-md-6.handsontable, .col-md-7.handsontable, .col-md-8.handsontable, .col-md-9.handsontable,
 .col-sm-1.handsontable, .col-sm-10.handsontable, .col-sm-11.handsontable, .col-sm-12.handsontable,
-.col-sm-2.handsontable, .col-sm-3.handsontable, .col-sm-4.handsontable, .col-sm-5.handsontable, .col-sm-6.handsontable, .col-sm-7.handsontable, .col-sm-8.handsontable, .col-sm-9.handsontable
+.col-sm-2.handsontable, .col-sm-3.handsontable, .col-sm-4.handsontable, .col-sm-5.handsontable, .col-sm-6.handsontable, .col-sm-7.handsontable, .col-sm-8.handsontable, .col-sm-9.handsontable,
 .col-xs-1.handsontable, .col-xs-10.handsontable, .col-xs-11.handsontable, .col-xs-12.handsontable,
 .col-xs-2.handsontable, .col-xs-3.handsontable, .col-xs-4.handsontable, .col-xs-5.handsontable, .col-xs-6.handsontable, .col-xs-7.handsontable, .col-xs-8.handsontable, .col-xs-9.handsontable {
   padding-left: 0;
@@ -129,8 +130,6 @@
 .handsontable textarea,
 .handsontable div {
   box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  -moz-box-sizing: content-box;
 }
 
 .handsontable input,
@@ -421,20 +420,6 @@
   bottom: 0;
   bottom: -100%\9; /* Fix for IE9 to spread the ":before" pseudo element to 100% height of the parent element */
   background: #005eff;
-}
-
-/* Fix for IE10 and IE11 to spread the ":before" pseudo element to 100% height of the parent element */
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .handsontable td.area:before,
-  .handsontable td.area-1:before,
-  .handsontable td.area-2:before,
-  .handsontable td.area-3:before,
-  .handsontable td.area-4:before,
-  .handsontable td.area-5:before,
-  .handsontable td.area-6:before,
-  .handsontable td.area-7:before {
-    bottom: -100%;
-  }
 }
 
 .handsontable td.area:before {
@@ -863,7 +848,6 @@ thead .htCollapseButton:after {
 .handsontable.mobile .wtHolder {
   -webkit-touch-callout:none;
   -webkit-user-select:none;
-  -khtml-user-select:none;
   -moz-user-select:none;
   -ms-user-select:none;
   user-select:none;
@@ -882,7 +866,6 @@ thead .htCollapseButton:after {
   border: 1px solid #ebebeb;
   z-index: 999;
   box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   -webkit-text-size-adjust: none;
 }
 
@@ -963,7 +946,7 @@ thead .htCollapseButton:after {
   top: 10pt;
   left: 5px;
   width: 30px;
-  bottom: 0px;
+  bottom: 0;
   cursor: move;
   z-index: 9999;
 }
@@ -1068,7 +1051,7 @@ thead .htCollapseButton:after {
   animation-fill-mode: forwards;
   -webkit-animation-fill-mode: forwards;
 }
-@charset "UTF-8";
+
 
 /*!
  * Pikaday
@@ -1220,7 +1203,6 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     cursor: pointer;
     display: block;
     box-sizing: border-box;
-    -moz-box-sizing: border-box;
     outline: none;
     border: 0;
     margin: 0;
@@ -1311,8 +1293,6 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 
 .htCommentTextArea {
     box-shadow: rgba(0, 0, 0, 0.117647) 0 1px 3px, rgba(0, 0, 0, 0.239216) 0 1px 2px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
     border: none;
     border-left: 3px solid #ccc;
@@ -1321,7 +1301,7 @@ http://nicolasgallagher.com/micro-clearfix-hack/
     height: 90px;
     font-size: 12px;
     padding: 5px;
-    outline: 0px !important;
+    outline: 0 !important;
     -webkit-appearance: none;
 }
 
@@ -1432,16 +1412,10 @@ textarea#HandsontableCopyPaste {
   position: relative;
 }
 .handsontable.ht__manualColumnMove.after-selection--columns thead th.ht__highlight {
-  cursor: move;
-  cursor: -moz-grab;
-  cursor: -webkit-grab;
   cursor: grab;
 }
 .handsontable.ht__manualColumnMove.on-moving--columns,
 .handsontable.ht__manualColumnMove.on-moving--columns thead th.ht__highlight {
-  cursor: move;
-  cursor: -moz-grabbing;
-  cursor: -webkit-grabbing;
   cursor: grabbing;
 }
 .handsontable.ht__manualColumnMove.on-moving--columns .manualColumnResizer {
@@ -1475,16 +1449,10 @@ textarea#HandsontableCopyPaste {
   position: relative;
 }
 .handsontable.ht__manualRowMove.after-selection--rows tbody th.ht__highlight {
-  cursor: move;
-  cursor: -moz-grab;
-  cursor: -webkit-grab;
   cursor: grab;
 }
 .handsontable.ht__manualRowMove.on-moving--rows,
 .handsontable.ht__manualRowMove.on-moving--rows tbody th.ht__highlight {
-  cursor: move;
-  cursor: -moz-grabbing;
-  cursor: -webkit-grabbing;
   cursor: grabbing;
 }
 .handsontable.ht__manualRowMove.on-moving--rows .manualRowResizer {


### PR DESCRIPTION
Fix #1771: Sheet CSS remove legacy styles no longer needed