### PR TITLE
Fixes #1792, check if calculator instance still exists

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/calculator/3-calculator.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/calculator/3-calculator.js
@@ -63,7 +63,7 @@ PrimeFaces.widget.ExtCalculator = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     _remove: function() {
-        if (this.input) {
+        if (this.input && this.input.data().calculator) {
             this.input.calculator('destroy');
             this.input = null;
         }


### PR DESCRIPTION
Fixes #1792, check if calculator instance still exists

The error seems to be due to the JQuery calculator plugin accessing a method on the calculator instance, which fails when the instance is undefined. So I added a check for whether an instance exists before calling "destroy".