### PR TITLE
Fixes #1794

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/dynaform/0-dynaform.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/dynaform/0-dynaform.js
@@ -17,7 +17,9 @@ PrimeFaces.widget.ExtDynaForm = PrimeFaces.widget.BaseWidget.extend({
         }
 
         if (cfg.autoSubmit && !PF(cfg.widgetVar)) {
-            this.submitForm();
+            // Delay submission until the CSP handler was registered, needed when CSP is enabled
+            // See https://github.com/primefaces-extensions/primefaces-extensions/issues/1794#issuecomment-2526318388
+            $(() => this.submitForm());
         } else if (cfg.isPostback && this.toggledExtended && this.uuid == cfg.uuid) {
             var rows = this.jq.find("tr.pe-dynaform-extendedrow");
             if (rows.length > 0) {


### PR DESCRIPTION
Fixes #1794. Just delaying the submission seems to work well.

Delay submission until the DOM is ready. When CSP is enabled, the AJAX click listener for the button is only registered by a script at the end of the <body>.