### PR TITLE
Fix #1886: SunEditor correct font-family in secure mode

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/suneditor/SunEditorRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/suneditor/SunEditorRenderer.java
@@ -22,7 +22,11 @@
 package org.primefaces.extensions.component.suneditor;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
@@ -32,6 +36,7 @@ import javax.faces.convert.Converter;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 
 /**
@@ -91,11 +96,66 @@ public class SunEditorRenderer extends InputRenderer {
 
         String valueToRender = editor.sanitizeHtml(context, ComponentUtils.getValueToRender(context, editor));
         if (valueToRender != null) {
+
+            // #1886 bug in sanitizer for font-family that has to be fixed
+            if (editor.isSecure()) {
+                valueToRender = fixFontFamily(valueToRender);
+            }
             // #1639 do not escape as its already been sanitized above, and we want to keep exact formatting
             writer.writeText(valueToRender, "value");
         }
 
         writer.endElement("textarea");
+    }
+
+    /**
+     * DIRTY HACK: Fixes the font-family declaration in the given HTML/CSS string by replacing any font name enclosed in `&#39;...&#39;` with its properly
+     * capitalized version.
+     * <p>
+     * Example:
+     *
+     * <pre>
+     * Input:  font-family:&#39;courier new&#39;
+     * Output: font-family: Courier New
+     * </pre>
+     *
+     * @param valueToRender the input string containing font-family declarations
+     * @return the modified string with font names properly capitalized and single quotes replaced
+     * @see <a href="https://github.com/OWASP/java-html-sanitizer/issues/232">OWASP Bug #232</a>
+     */
+    protected String fixFontFamily(String valueToRender) {
+        // Regex to match font-family declarations with any font name inside &#39;...&#39;
+        String regex = "font-family:\\s*&#39;([^&#]+)&#39;";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(valueToRender);
+
+        // StringBuilder for efficient string manipulation
+        StringBuilder result = new StringBuilder();
+
+        while (matcher.find()) {
+            // Extract the font name inside &#39;...&#39;
+            String fontName = matcher.group(1);
+
+            // Capitalize each word in the font name separately
+            String correctedFont = Arrays.stream(fontName.split("\\s+")) // Split by space
+                        .map(LangUtils::capitalize) // Capitalize each word
+                        .collect(Collectors.joining(" ")); // Join back with spaces
+
+            if (correctedFont.endsWith(" Ms")) {
+                correctedFont = correctedFont.replace(" Ms", " MS");
+            }
+            if ("tahoma".equalsIgnoreCase(correctedFont)) {
+                correctedFont = correctedFont.replace("Tahoma", "tahoma");
+            }
+
+            // Replace the matched pattern with the corrected font-family declaration
+            matcher.appendReplacement(result, "font-family: " + correctedFont);
+        }
+
+        // Append any remaining part of the input string
+        matcher.appendTail(result);
+
+        return result.toString();
     }
 
     protected void encodeScript(final FacesContext context, final SunEditor editor) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <libphonenumber.version>9.0.0</libphonenumber.version>
         <morphia.version>2.4.15</morphia.version>
         <junit.version>5.12.0</junit.version>
-        <primefaces.core.version>15.0.0</primefaces.core.version>
+        <primefaces.core.version>15.0.1</primefaces.core.version>
         <primefaces.optimizer.version>2.6.5</primefaces.optimizer.version>
         <withoutCompress>true</withoutCompress>
     </properties>


### PR DESCRIPTION
Fix #1886: SunEditor correct font-family in secure mode