### PR TITLE
Update pdf.viewer.js

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/pdf.viewer.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/pdf.viewer.js
@@ -14153,6 +14153,11 @@ class CanvasGraphics {
     const patternFill = current.patternFill && !font.missingFile;
     const patternStroke = current.patternStroke && !font.missingFile;
     let path;
+
+    // PrimeFaces (#1864), bugfix when you have embedded and not embedded fonts inside the same pdf.
+    // Normally pdf.js is able to handle this, but not in our case with the displaying iframe
+    font.disableFontFace = !font.missingFile || font.mimetype;
+
     if (font.disableFontFace || isAddToPathSet || patternFill || patternStroke) {
       path = font.getPathGenerator(this.commonObjs, character);
     }


### PR DESCRIPTION
PrimeFaces (#1864), bugfix when you have embedded and not embedded fonts inside the same pdf. Normally pdf.js is able to handle this, but not in our case with the displaying iframe.

The orginal change / idea for the change was not from me, i found it here https://github.com/mozilla/pdf.js/issues/11311#issuecomment-863714376
