### PR TITLE
Fix #1864: 14.x fix PDF with embedded and non embedded fonts

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/pdf.viewer.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/pdf.viewer.js
@@ -12038,6 +12038,9 @@ class CanvasGraphics {
     const isAddToPathSet = !!(textRenderingMode & TextRenderingMode.ADD_TO_PATH_FLAG);
     const patternFill = current.patternFill && !font.missingFile;
     let addToPath;
+    // PrimeFaces (#1864), bugfix when you have embedded and not embedded fonts inside the same pdf.
+    // Normally pdf.js is able to handle this, but not in our case with the displaying iframe
+    font.disableFontFace = !font.missingFile || font.mimetype;
     if (font.disableFontFace || isAddToPathSet || patternFill) {
       addToPath = font.getPathGenerator(this.commonObjs, character);
     }


### PR DESCRIPTION
Fix #1864: 14.x fix PDF with embedded and non embedded fonts