### PR TITLE
Resolve #1933: Refactoring: Align @ResourceDependency usage by replacing hardcoded library names with Constants.LIBRARY

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/behavior/javascript/JavascriptBehavior.java
+++ b/core/src/main/java/org/primefaces/extensions/behavior/javascript/JavascriptBehavior.java
@@ -25,6 +25,7 @@ import javax.faces.application.ResourceDependency;
 
 import org.primefaces.behavior.base.AbstractBehavior;
 import org.primefaces.behavior.base.BehaviorAttribute;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * Client Behavior class for the <code>Javascript</code> behavior.
@@ -36,7 +37,7 @@ import org.primefaces.behavior.base.BehaviorAttribute;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
 public class JavascriptBehavior extends AbstractBehavior {
 
     public static final String BEHAVIOR_ID = "org.primefaces.extensions.behavior.JavascriptBehavior";

--- a/core/src/main/java/org/primefaces/extensions/component/blockui/BlockUI.java
+++ b/core/src/main/java/org/primefaces/extensions/component/blockui/BlockUI.java
@@ -25,6 +25,7 @@ import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIComponentBase;
 
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * <code>BlockUI</code> component.
@@ -37,9 +38,9 @@ import org.primefaces.component.api.Widget;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "blockui/blockui.css")
-@ResourceDependency(library = "primefaces-extensions", name = "blockui/blockui.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "blockui/blockui.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "blockui/blockui.js")
 public class BlockUI extends UIComponentBase implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.BlockUI";

--- a/core/src/main/java/org/primefaces/extensions/component/calculator/Calculator.java
+++ b/core/src/main/java/org/primefaces/extensions/component/calculator/Calculator.java
@@ -49,8 +49,8 @@ import org.primefaces.util.LocaleUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "calculator/calculator.css")
-@ResourceDependency(library = "primefaces-extensions", name = "calculator/calculator.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "calculator/calculator.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "calculator/calculator.js")
 public class Calculator extends UIComponentBase implements ClientBehaviorHolder, Widget, RTLAware {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Calculator";

--- a/core/src/main/java/org/primefaces/extensions/component/clipboard/Clipboard.java
+++ b/core/src/main/java/org/primefaces/extensions/component/clipboard/Clipboard.java
@@ -48,7 +48,7 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "clipboard/clipboard.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "clipboard/clipboard.js")
 public class Clipboard extends UIComponentBase implements ClientBehaviorHolder, Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Clipboard";

--- a/core/src/main/java/org/primefaces/extensions/component/clockpicker/ClockPicker.java
+++ b/core/src/main/java/org/primefaces/extensions/component/clockpicker/ClockPicker.java
@@ -29,14 +29,15 @@ import javax.faces.context.FacesContext;
 import org.primefaces.component.api.AbstractPrimeHtmlInputText;
 import org.primefaces.component.api.InputHolder;
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 import org.primefaces.util.LocaleUtils;
 
 @ResourceDependency(library = "primefaces", name = "components.css")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "clockpicker/clockpicker.css")
-@ResourceDependency(library = "primefaces-extensions", name = "clockpicker/clockpicker.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "clockpicker/clockpicker.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "clockpicker/clockpicker.js")
 public class ClockPicker extends AbstractPrimeHtmlInputText implements Widget, InputHolder {
     public static final String CONTAINER_CLASS = "pe-clockpicker ui-widget ui-corner-all clockpicker";
     public static final String BUTTON_TRIGGER_CLASS = "pe-clockpicker-trigger ui-button ui-widget ui-state-default ui-corner-all ui-button-icon-only input-group-addon";

--- a/core/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirror.java
+++ b/core/src/main/java/org/primefaces/extensions/component/codemirror/CodeMirror.java
@@ -34,6 +34,7 @@ import javax.faces.event.FacesEvent;
 import org.primefaces.component.api.AbstractPrimeHtmlInputTextArea;
 import org.primefaces.component.api.Widget;
 import org.primefaces.extensions.event.CompleteEvent;
+import org.primefaces.extensions.util.Constants;
 import org.primefaces.util.LangUtils;
 
 /**
@@ -46,9 +47,9 @@ import org.primefaces.util.LangUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "codemirror/codemirror.js")
-@ResourceDependency(library = "primefaces-extensions", name = "codemirror/codemirror.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "codemirror/codemirror.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "codemirror/codemirror.css")
 public class CodeMirror extends AbstractPrimeHtmlInputTextArea implements ClientBehaviorHolder, Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.CodeMirror";

--- a/core/src/main/java/org/primefaces/extensions/component/codescanner/CodeScanner.java
+++ b/core/src/main/java/org/primefaces/extensions/component/codescanner/CodeScanner.java
@@ -49,7 +49,7 @@ import org.primefaces.util.LangUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "codescanner/codescanner.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "codescanner/codescanner.js")
 public class CodeScanner extends UIComponentBase implements Widget, ClientBehaviorHolder, MixedClientBehaviorHolder {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.CodeScanner";

--- a/core/src/main/java/org/primefaces/extensions/component/counter/Counter.java
+++ b/core/src/main/java/org/primefaces/extensions/component/counter/Counter.java
@@ -47,7 +47,7 @@ import org.primefaces.util.MapBuilder;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
 @ResourceDependency(library = "primefaces", name = "components.js")
-@ResourceDependency(library = "primefaces-extensions", name = "counter/counter.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "counter/counter.js")
 public class Counter extends CounterBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Counter";

--- a/core/src/main/java/org/primefaces/extensions/component/creditcard/CreditCard.java
+++ b/core/src/main/java/org/primefaces/extensions/component/creditcard/CreditCard.java
@@ -25,6 +25,7 @@ import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIComponentBase;
 
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * <code>CreditCard</code> component.
@@ -36,8 +37,8 @@ import org.primefaces.component.api.Widget;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "creditcard/creditcard.css")
-@ResourceDependency(library = "primefaces-extensions", name = "creditcard/creditcard.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "creditcard/creditcard.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "creditcard/creditcard.js")
 public class CreditCard extends UIComponentBase implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.CreditCard";

--- a/core/src/main/java/org/primefaces/extensions/component/documentviewer/DocumentViewer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/documentviewer/DocumentViewer.java
@@ -27,6 +27,7 @@ import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIGraphic;
 import javax.faces.context.FacesContext;
 
+import org.primefaces.extensions.util.Constants;
 import org.primefaces.util.LocaleUtils;
 
 /**
@@ -39,7 +40,7 @@ import org.primefaces.util.LocaleUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
 public class DocumentViewer extends UIGraphic {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.DocumentViewer";

--- a/core/src/main/java/org/primefaces/extensions/component/dynaform/DynaForm.java
+++ b/core/src/main/java/org/primefaces/extensions/component/dynaform/DynaForm.java
@@ -40,6 +40,7 @@ import org.primefaces.extensions.component.base.AbstractDynamicData;
 import org.primefaces.extensions.model.common.KeyData;
 import org.primefaces.extensions.model.dynaform.DynaFormControl;
 import org.primefaces.extensions.model.dynaform.DynaFormModel;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * <code>DynaForm</code> component.
@@ -51,9 +52,9 @@ import org.primefaces.extensions.model.dynaform.DynaFormModel;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "dynaform/dynaform.css")
-@ResourceDependency(library = "primefaces-extensions", name = "dynaform/dynaform.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "dynaform/dynaform.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "dynaform/dynaform.js")
 public class DynaForm extends AbstractDynamicData implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.DynaForm";

--- a/core/src/main/java/org/primefaces/extensions/component/echarts/EChart.java
+++ b/core/src/main/java/org/primefaces/extensions/component/echarts/EChart.java
@@ -40,7 +40,7 @@ import org.primefaces.util.MapBuilder;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
 @ResourceDependency(library = "primefaces", name = "components.js")
-@ResourceDependency(library = "primefaces-extensions", name = "echarts/echarts.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "echarts/echarts.js")
 public class EChart extends EChartBase {
     private static final String DEFAULT_EVENT = "itemSelect";
 

--- a/core/src/main/java/org/primefaces/extensions/component/fluidgrid/FluidGrid.java
+++ b/core/src/main/java/org/primefaces/extensions/component/fluidgrid/FluidGrid.java
@@ -52,9 +52,9 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "fluidgrid/fluidgrid.css")
-@ResourceDependency(library = "primefaces-extensions", name = "fluidgrid/fluidgrid.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "fluidgrid/fluidgrid.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "fluidgrid/fluidgrid.js")
 public class FluidGrid extends AbstractDynamicData implements Widget, ClientBehaviorHolder {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.FluidGrid";

--- a/core/src/main/java/org/primefaces/extensions/component/fuzzysearch/FuzzySearch.java
+++ b/core/src/main/java/org/primefaces/extensions/component/fuzzysearch/FuzzySearch.java
@@ -46,7 +46,7 @@ import org.primefaces.util.MapBuilder;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
 @ResourceDependency(library = "primefaces", name = "components.js")
-@ResourceDependency(library = "primefaces-extensions", name = "fuzzysearch/fuzzysearch.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "fuzzysearch/fuzzysearch.js")
 public class FuzzySearch extends FuzzySearchBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.FuzzySearch";

--- a/core/src/main/java/org/primefaces/extensions/component/gchart/GChart.java
+++ b/core/src/main/java/org/primefaces/extensions/component/gchart/GChart.java
@@ -41,9 +41,9 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "gchart/gchart.css")
-@ResourceDependency(library = "primefaces-extensions", name = "gchart/gchart.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "gchart/gchart.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "gchart/gchart.js")
 public class GChart extends UIOutput implements Widget, ClientBehaviorHolder {
 
     public static final String API_KEY = "primefaces.GOOGLE_MAPS_API_KEY";

--- a/core/src/main/java/org/primefaces/extensions/component/imageareaselect/ImageAreaSelect.java
+++ b/core/src/main/java/org/primefaces/extensions/component/imageareaselect/ImageAreaSelect.java
@@ -47,9 +47,9 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "imageareaselect/imageareaselect.css")
-@ResourceDependency(library = "primefaces-extensions", name = "imageareaselect/imageareaselect.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "imageareaselect/imageareaselect.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "imageareaselect/imageareaselect.js")
 public class ImageAreaSelect extends UIComponentBase implements Widget, ClientBehaviorHolder {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.ImageAreaSelect";

--- a/core/src/main/java/org/primefaces/extensions/component/imagerotateandresize/ImageRotateAndResize.java
+++ b/core/src/main/java/org/primefaces/extensions/component/imagerotateandresize/ImageRotateAndResize.java
@@ -48,8 +48,8 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "imagerotateandresize/imagerotateandresize.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "imagerotateandresize/imagerotateandresize.js")
 public class ImageRotateAndResize extends UIComponentBase implements Widget, ClientBehaviorHolder {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.ImageRotateAndResize";

--- a/core/src/main/java/org/primefaces/extensions/component/imagezoom/ImageZoom.java
+++ b/core/src/main/java/org/primefaces/extensions/component/imagezoom/ImageZoom.java
@@ -25,6 +25,7 @@ import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIComponentBase;
 
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * Component class for the <code>ImageZoom</code> component.
@@ -35,9 +36,9 @@ import org.primefaces.component.api.Widget;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "imagezoom/imagezoom.js")
-@ResourceDependency(library = "primefaces-extensions", name = "imagezoom/imagezoom.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "imagezoom/imagezoom.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "imagezoom/imagezoom.css")
 public class ImageZoom extends UIComponentBase implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.ImageZoom";

--- a/core/src/main/java/org/primefaces/extensions/component/inputphone/InputPhone.java
+++ b/core/src/main/java/org/primefaces/extensions/component/inputphone/InputPhone.java
@@ -51,8 +51,8 @@ import org.primefaces.util.LangUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "inputphone/inputphone.css")
-@ResourceDependency(library = "primefaces-extensions", name = "inputphone/inputphone.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "inputphone/inputphone.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "inputphone/inputphone.js")
 public class InputPhone extends AbstractPrimeHtmlInputText implements Widget, InputHolder, MixedClientBehaviorHolder, RTLAware {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.InputPhone";

--- a/core/src/main/java/org/primefaces/extensions/component/keynote/Keynote.java
+++ b/core/src/main/java/org/primefaces/extensions/component/keynote/Keynote.java
@@ -51,9 +51,9 @@ import org.primefaces.util.MapBuilder;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "keynote/keynote.js")
-@ResourceDependency(library = "primefaces-extensions", name = "keynote/keynote.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "keynote/keynote.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "keynote/keynote.css")
 public class Keynote extends AbstractDynamicData implements Widget, ClientBehaviorHolder, PrimeClientBehaviorHolder {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Keynote";

--- a/core/src/main/java/org/primefaces/extensions/component/layout/Layout.java
+++ b/core/src/main/java/org/primefaces/extensions/component/layout/Layout.java
@@ -54,9 +54,9 @@ import org.primefaces.util.LangUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "layout/layout.css")
-@ResourceDependency(library = "primefaces-extensions", name = "layout/layout.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "layout/layout.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "layout/layout.js")
 public class Layout extends UIComponentBase implements Widget, ClientBehaviorHolder {
 
     public static final String POSITION_SEPARATOR = "_";

--- a/core/src/main/java/org/primefaces/extensions/component/legend/Legend.java
+++ b/core/src/main/java/org/primefaces/extensions/component/legend/Legend.java
@@ -27,6 +27,7 @@ import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIComponentBase;
 
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * <code>Legend</code> component.
@@ -38,8 +39,8 @@ import org.primefaces.component.api.Widget;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "legend/legend.css")
-@ResourceDependency(library = "primefaces-extensions", name = "legend/legend.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "legend/legend.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "legend/legend.js")
 public class Legend extends UIComponentBase implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Legend";

--- a/core/src/main/java/org/primefaces/extensions/component/lightswitch/LightSwitch.java
+++ b/core/src/main/java/org/primefaces/extensions/component/lightswitch/LightSwitch.java
@@ -46,8 +46,8 @@ import org.primefaces.util.LangUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "lightswitch/lightswitch.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "lightswitch/lightswitch.js")
 public class LightSwitch extends UIComponentBase implements Widget, ClientBehaviorHolder, MixedClientBehaviorHolder {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.LightSwitch";

--- a/core/src/main/java/org/primefaces/extensions/component/masterdetail/MasterDetail.java
+++ b/core/src/main/java/org/primefaces/extensions/component/masterdetail/MasterDetail.java
@@ -47,7 +47,7 @@ import org.primefaces.util.LangUtils;
  * @version $Revision$
  * @since 0.2
  */
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.css")
 public class MasterDetail extends UIComponentBase {
 
     public static final String CONTEXT_VALUE_VALUE_EXPRESSION = "mdContextValueVE";

--- a/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoDiffEditorFramed.java
+++ b/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoDiffEditorFramed.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import javax.faces.application.ResourceDependency;
 import javax.faces.event.BehaviorEvent;
 
+import org.primefaces.extensions.util.Constants;
+
 /**
  * Component for the Monaco code diff editor JavaScript library .This is the framed monaco editor that creates a new instance in a separate iframe to allow for
  * better scoping, i.e. loading types etc. without affecting other editors. There is also an inline widget when this scoping is not required as iframes create
@@ -38,9 +40,9 @@ import javax.faces.event.BehaviorEvent;
 @SuppressWarnings("java:S110")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "monacoeditor/widget-framed.js")
-@ResourceDependency(library = "primefaces-extensions", name = "monacoeditor/monacoeditor.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "monacoeditor/widget-framed.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "monacoeditor/monacoeditor.css")
 public class MonacoDiffEditorFramed extends MonacoDiffEditorBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.MonacoDiffEditorFramed";

--- a/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoDiffEditorInline.java
+++ b/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoDiffEditorInline.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import javax.faces.application.ResourceDependency;
 import javax.faces.event.BehaviorEvent;
 
+import org.primefaces.extensions.util.Constants;
+
 /**
  * Component for the Monaco diff code editor JavaScript library. This is the inline monaco editor that creates a new instance in a textarea element on the same
  * page. There is also framed version available that creates an editor in an iframe for better scoping.
@@ -37,9 +39,9 @@ import javax.faces.event.BehaviorEvent;
 @SuppressWarnings("java:S110")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "monacoeditor/widget-inline.js")
-@ResourceDependency(library = "primefaces-extensions", name = "monacoeditor/monacoeditor.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "monacoeditor/widget-inline.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "monacoeditor/monacoeditor.css")
 public class MonacoDiffEditorInline extends MonacoDiffEditorBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.MonacoDiffEditorInline";

--- a/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoEditorFramed.java
+++ b/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoEditorFramed.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import javax.faces.application.ResourceDependency;
 import javax.faces.event.BehaviorEvent;
 
+import org.primefaces.extensions.util.Constants;
+
 /**
  * Component for the Monaco code editor JavaScript library .This is the framed Monaco editor that creates a new instance in a separate iframe to allow for
  * better scoping, i.e. loading types etc. without affecting other editors. There is also an inline widget when this scoping is not required as iframes create
@@ -38,9 +40,9 @@ import javax.faces.event.BehaviorEvent;
 @SuppressWarnings("java:S110")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "monacoeditor/widget-framed.js")
-@ResourceDependency(library = "primefaces-extensions", name = "monacoeditor/monacoeditor.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "monacoeditor/widget-framed.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "monacoeditor/monacoeditor.css")
 public class MonacoEditorFramed extends MonacoEditorBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.MonacoEditorFramed";

--- a/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoEditorInline.java
+++ b/core/src/main/java/org/primefaces/extensions/component/monacoeditor/MonacoEditorInline.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import javax.faces.application.ResourceDependency;
 import javax.faces.event.BehaviorEvent;
 
+import org.primefaces.extensions.util.Constants;
+
 /**
  * Component for the Monaco code editor JavaScript library. This is the inline monaco editor that creates a new instance in a textarea element on the same page.
  * There is also framed version available that creates an editor in an iframe for better scoping.
@@ -37,9 +39,9 @@ import javax.faces.event.BehaviorEvent;
 @SuppressWarnings("java:S110")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "monacoeditor/widget-inline.js")
-@ResourceDependency(library = "primefaces-extensions", name = "monacoeditor/monacoeditor.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "monacoeditor/widget-inline.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "monacoeditor/monacoeditor.css")
 public class MonacoEditorInline extends MonacoEditorBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.MonacoEditorInline";

--- a/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChart.java
+++ b/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChart.java
@@ -48,9 +48,9 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "orgchart/orgchart.js")
-@ResourceDependency(library = "primefaces-extensions", name = "orgchart/orgchart.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "orgchart/orgchart.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "orgchart/orgchart.css")
 public class OrgChart extends UIData implements Widget, ClientBehaviorHolder {
 
     public static final String STYLE_CLASS = "ui-orgchart ";

--- a/core/src/main/java/org/primefaces/extensions/component/osmap/OSMap.java
+++ b/core/src/main/java/org/primefaces/extensions/component/osmap/OSMap.java
@@ -38,10 +38,10 @@ import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 import org.primefaces.util.MapBuilder;
 
-@ResourceDependency(library = "primefaces-extensions", name = "leaflet/leaflet.css")
-@ResourceDependency(library = "primefaces-extensions", name = "leaflet/leaflet.js")
-@ResourceDependency(library = "primefaces-extensions", name = "osmap/osmap.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "leaflet/leaflet.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "leaflet/leaflet.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "osmap/osmap.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
 public class OSMap extends OSMapBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.OSMap";

--- a/core/src/main/java/org/primefaces/extensions/component/qrcode/QRCode.java
+++ b/core/src/main/java/org/primefaces/extensions/component/qrcode/QRCode.java
@@ -25,6 +25,7 @@ import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIOutput;
 
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * <code>QRCode</code> component.
@@ -35,8 +36,8 @@ import org.primefaces.component.api.Widget;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "qrcode/qrcode.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "qrcode/qrcode.js")
 public class QRCode extends UIOutput implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.QRCode";

--- a/core/src/main/java/org/primefaces/extensions/component/remotecommand/RemoteCommand.java
+++ b/core/src/main/java/org/primefaces/extensions/component/remotecommand/RemoteCommand.java
@@ -40,6 +40,7 @@ import org.primefaces.component.api.AjaxSource;
 import org.primefaces.extensions.component.base.AbstractParameter;
 import org.primefaces.extensions.component.parameters.AssignableParameter;
 import org.primefaces.extensions.component.parameters.MethodParameter;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * Component class for the <code>RemoteCommand</code> component.
@@ -51,7 +52,7 @@ import org.primefaces.extensions.component.parameters.MethodParameter;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
 public class RemoteCommand extends UICommand implements AjaxSource {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.RemoteCommand";

--- a/core/src/main/java/org/primefaces/extensions/component/session/Session.java
+++ b/core/src/main/java/org/primefaces/extensions/component/session/Session.java
@@ -26,6 +26,7 @@ import javax.faces.component.FacesComponent;
 import javax.faces.component.UIComponentBase;
 
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * <code>Session</code> component.
@@ -38,7 +39,7 @@ import org.primefaces.component.api.Widget;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "session/session.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "session/session.js")
 public class Session extends UIComponentBase implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Session";

--- a/core/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
+++ b/core/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
@@ -69,9 +69,9 @@ import org.primefaces.util.LangUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
 @ResourceDependency(library = "primefaces", name = "components.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", target = "head", name = "sheet/sheet.css")
-@ResourceDependency(library = "primefaces-extensions", name = "sheet/sheet.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, target = "head", name = "sheet/sheet.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "sheet/sheet.js")
 public class Sheet extends SheetBase {
 
     public static final String EVENT_CELL_SELECT = "cellSelect";

--- a/core/src/main/java/org/primefaces/extensions/component/slideout/SlideOut.java
+++ b/core/src/main/java/org/primefaces/extensions/component/slideout/SlideOut.java
@@ -48,8 +48,8 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "slideout/slideout.css")
-@ResourceDependency(library = "primefaces-extensions", name = "slideout/slideout.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "slideout/slideout.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "slideout/slideout.js")
 public class SlideOut extends UIComponentBase implements ClientBehaviorHolder, Widget {
 
     public static final String HANDLE_CLASS = "ui-slideout-handle ui-slideouttab-handle-rounded";

--- a/core/src/main/java/org/primefaces/extensions/component/speedtest/Speedtest.java
+++ b/core/src/main/java/org/primefaces/extensions/component/speedtest/Speedtest.java
@@ -46,9 +46,9 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "echarts/echarts.js")
-@ResourceDependency(library = "primefaces-extensions", name = "speedtest/speedtest.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "echarts/echarts.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "speedtest/speedtest.js")
 public class Speedtest extends UIComponentBase implements ClientBehaviorHolder, Widget {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.extensions.component";

--- a/core/src/main/java/org/primefaces/extensions/component/suneditor/SunEditor.java
+++ b/core/src/main/java/org/primefaces/extensions/component/suneditor/SunEditor.java
@@ -29,6 +29,7 @@ import javax.faces.component.behavior.ClientBehaviorHolder;
 import javax.faces.context.FacesContext;
 
 import org.primefaces.extensions.component.base.AbstractEditorInputTextArea;
+import org.primefaces.extensions.util.Constants;
 import org.primefaces.util.LangUtils;
 import org.primefaces.util.LocaleUtils;
 
@@ -42,9 +43,9 @@ import org.primefaces.util.LocaleUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "suneditor/suneditor.css")
-@ResourceDependency(library = "primefaces-extensions", name = "suneditor/suneditor.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "suneditor/suneditor.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "suneditor/suneditor.js")
 public class SunEditor extends AbstractEditorInputTextArea implements ClientBehaviorHolder {
     public static final String EDITOR_CLASS = "ui-suneditor";
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.SunEditor";

--- a/core/src/main/java/org/primefaces/extensions/component/timeago/TimeAgo.java
+++ b/core/src/main/java/org/primefaces/extensions/component/timeago/TimeAgo.java
@@ -36,6 +36,7 @@ import javax.faces.component.UIComponentBase;
 import javax.faces.context.FacesContext;
 
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 import org.primefaces.util.LocaleUtils;
 
 /**
@@ -46,8 +47,8 @@ import org.primefaces.util.LocaleUtils;
  */
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "timeago/timeago.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "timeago/timeago.js")
 public class TimeAgo extends UIComponentBase implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.TimeAgo";

--- a/core/src/main/java/org/primefaces/extensions/component/timepicker/TimePicker.java
+++ b/core/src/main/java/org/primefaces/extensions/component/timepicker/TimePicker.java
@@ -55,9 +55,9 @@ import org.primefaces.util.LocaleUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "timepicker/timepicker.css")
-@ResourceDependency(library = "primefaces-extensions", name = "timepicker/timepicker.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "timepicker/timepicker.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "timepicker/timepicker.js")
 public class TimePicker extends AbstractPrimeHtmlInputText implements Widget, InputHolder {
 
     public static final String CONTAINER_CLASS = "pe-timepicker ui-widget ui-corner-all";

--- a/core/src/main/java/org/primefaces/extensions/component/timer/Timer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/timer/Timer.java
@@ -43,9 +43,9 @@ import org.primefaces.util.LocaleUtils;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
 @ResourceDependency(library = "primefaces", name = "moment/moment.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "timer/timer.css")
-@ResourceDependency(library = "primefaces-extensions", name = "timer/timer.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "timer/timer.css")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "timer/timer.js")
 public class Timer extends UIComponentBase implements Widget, AjaxSource {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Timer";

--- a/core/src/main/java/org/primefaces/extensions/component/tooltip/Tooltip.java
+++ b/core/src/main/java/org/primefaces/extensions/component/tooltip/Tooltip.java
@@ -25,6 +25,7 @@ import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIOutput;
 
 import org.primefaces.component.api.Widget;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * <code>Tooltip</code> component.
@@ -35,9 +36,9 @@ import org.primefaces.component.api.Widget;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "tooltip/tooltip.css")
-@ResourceDependency(library = "primefaces-extensions", name = "tooltip/tooltip.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "tooltip/tooltip.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "tooltip/tooltip.js")
 public class Tooltip extends UIOutput implements Widget {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Tooltip";

--- a/core/src/main/java/org/primefaces/extensions/component/tristatemanycheckbox/TriStateManyCheckbox.java
+++ b/core/src/main/java/org/primefaces/extensions/component/tristatemanycheckbox/TriStateManyCheckbox.java
@@ -48,8 +48,8 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "tristatemanycheckbox/tristatemanycheckbox.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "tristatemanycheckbox/tristatemanycheckbox.js")
 public class TriStateManyCheckbox extends HtmlSelectManyCheckbox implements Widget {
 
     public static final String UI_ICON = "ui-icon ";

--- a/core/src/main/java/org/primefaces/extensions/component/waypoint/Waypoint.java
+++ b/core/src/main/java/org/primefaces/extensions/component/waypoint/Waypoint.java
@@ -43,8 +43,8 @@ import org.primefaces.util.Constants;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = "primefaces-extensions", name = "primefaces-extensions.js")
-@ResourceDependency(library = "primefaces-extensions", name = "waypoint/waypoint.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "waypoint/waypoint.js")
 public class Waypoint extends UIComponentBase implements Widget, ClientBehaviorHolder {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.Waypoint";


### PR DESCRIPTION
Resolve #1933 

Note that in some cases we need to use full package name since the short name has already been used by `org.primefaces.util.Constants;` 