### PR TITLE
Fix #1964: PDF Viewer remove `file origin does not match viewer`

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/pdf.viewer.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/documentviewer/pdf.viewer.js
@@ -49404,11 +49404,12 @@ initCom(PDFViewerApplication);
     if (fileOrigin === viewerOrigin) {
       return;
     }
-    const ex = new Error("file origin does not match viewer's");
-    PDFViewerApplication._documentError("pdfjs-loading-error", {
-      message: ex.message
-    });
-    throw ex;
+	// PrimeFaces Extensions remove this check so users can use URL's and Streams
+    //const ex = new Error("file origin does not match viewer's");
+    //PDFViewerApplication._documentError("pdfjs-loading-error", {
+    //  message: ex.message
+    //});
+    //throw ex;
   };
   var onFileInputChange = function (evt) {
     if (this.pdfViewer?.isInPresentationMode) {


### PR DESCRIPTION
Fix #1964: PDF Viewer remove `file origin does not match viewer`