### PR TITLE
Fix #1973: CodeScanner missing JS

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,6 +115,7 @@
                 <filtering>false</filtering>
                 <includes>
                     <include>**/documentviewer/**</include>
+                    <include>**/codescanner/**</include>
                 </includes>
             </resource>
         </resources>


### PR DESCRIPTION
Fix #1973: CodeScanner missing JS