### PR TITLE
Fix #1990: Clipboard add DOM element

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/clipboard/1-clipboard-widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/clipboard/1-clipboard-widget.js
@@ -64,7 +64,7 @@ PrimeFaces.widget.ExtClipboard = PrimeFaces.widget.BaseWidget.extend({
         this.trigger = _trigger;
 
         // destroy the old Clipboard
-        this.destroy();
+        this._remove();
 
         // start building the options to configure the clipboard
         var opts = {


### PR DESCRIPTION
Fix #1990: Clipboard add DOM element

@tandraschko maybe there is something I am missing but even adding this I am still seeing the `Destroyed detached widget: widget_clipCopy` and I don't understand why.