### PR TITLE
Fix #1050: OrgChart: FontAwesome icons no longer work

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/3-orgchart-widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/3-orgchart-widget.js
@@ -29,6 +29,18 @@ PrimeFaces.widget.ExtOrgChart = class extends PrimeFaces.widget.BaseWidget {
         var opts = $.extend(true, {}, cfg);
         opts['data'] = JSON.parse(opts['data']);
 
+        // Map parentNodeSymbol to icons.parentNode
+        if (opts.parentNodeSymbol) {
+            opts.icons = opts.icons || {};
+            opts.icons.parentNode = opts.parentNodeSymbol;
+            // Set theme based on icon prefix
+            if (opts.parentNodeSymbol.startsWith('fa-')) {
+                opts.icons.theme = 'fa';
+            } else if (opts.parentNodeSymbol.startsWith('oci-')) {
+                opts.icons.theme = 'oci';
+            }
+        }
+
         this.orgchart = this.jq.orgchart(opts);
 
         this._bindEvents();

--- a/showcase/src/main/webapp/sections/orgchart/example-basicUsage.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/example-basicUsage.xhtml
@@ -13,7 +13,7 @@
                 draggable="true"
                 exportButton="true"
                 pan="true"
-                parentNodeSymbol="oci-leader"
+                parentNodeSymbol="fa-folder-open"
                 zoom="true"
                 exportFileextension="pdf"
                 direction="#{orgchartController.direction}"


### PR DESCRIPTION
Fix #1050

Refer to: https://github.com/dabeng/OrgChart/issues/695#issuecomment-1541431960

Orgchart upstream sample code: https://codepen.io/dabeng/pen/jOezQzy

---

Updated showcase sample:

http://localhost:8080/showcase/sections/orgchart/basicUsage.jsf

<img width="710" height="349" alt="image" src="https://github.com/user-attachments/assets/8f2b002d-8716-4876-b2bd-70f6c123d59d" />
