### PR TITLE
BackPort: Fix #1050: OrgChart: FontAwesome icons no longer work

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/3-orgchart-widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/3-orgchart-widget.js
@@ -29,6 +29,18 @@ PrimeFaces.widget.ExtOrgChart = PrimeFaces.widget.BaseWidget.extend({
         var opts = $.extend(true, {}, cfg);
         opts['data'] = JSON.parse(opts['data']);
 
+        // Map parentNodeSymbol to icons.parentNode
+        if (opts.parentNodeSymbol) {
+            opts.icons = opts.icons || {};
+            opts.icons.parentNode = opts.parentNodeSymbol;
+            // Set theme based on icon prefix
+            if (opts.parentNodeSymbol.startsWith('fa-')) {
+                opts.icons.theme = 'fa';
+            } else if (opts.parentNodeSymbol.startsWith('oci-')) {
+                opts.icons.theme = 'oci';
+            }
+        }
+
         this.orgchart = this.jq.orgchart(opts);
 
         this._bindEvents();
@@ -70,5 +82,6 @@ PrimeFaces.widget.ExtOrgChart = PrimeFaces.widget.BaseWidget.extend({
             $this.callBehavior('drop', options);
 
         });
+
     }
 });

--- a/showcase/src/main/webapp/sections/orgchart/example-basicUsage.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/example-basicUsage.xhtml
@@ -13,7 +13,7 @@
                 draggable="true"
                 exportButton="true"
                 pan="true"
-                parentNodeSymbol="oci-leader"
+                parentNodeSymbol="fa-folder-open"
                 zoom="true"
                 exportFileextension="pdf"
                 direction="#{orgchartController.direction}"


### PR DESCRIPTION
- Map parentNodeSymbol to icons.parentNode in the widget JS
- Set icons.theme based on icon prefix (fa- for FontAwesome, oci- for others)