### PR TITLE
#129 Add MarkText showcase enhancements with new demo pages

### DIFF
--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/MarkTextController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/MarkTextController.java
@@ -39,12 +39,62 @@ public class MarkTextController implements Serializable {
 
     private String searchTerm = "ipsum";
 
+    private String searchTerm2 = "dolor";
+
+    private String customStyleClass = "custom-highlight";
+
+    private String searchTermCaseSensitivity = "Ut";
+
+    private String searchTermSeparateWord = "search is there";
+
+    private String searchTermAccuracy = "am";
+
     public String getSearchTerm() {
         return searchTerm;
     }
 
     public void setSearchTerm(String searchTerm) {
         this.searchTerm = searchTerm;
+    }
+
+    public String getSearchTerm2() {
+        return searchTerm2;
+    }
+
+    public void setSearchTerm2(String searchTerm2) {
+        this.searchTerm2 = searchTerm2;
+    }
+
+    public String getCustomStyleClass() {
+        return customStyleClass;
+    }
+
+    public void setCustomStyleClass(String customStyleClass) {
+        this.customStyleClass = customStyleClass;
+    }
+
+    public String getSearchTermCaseSensitivity() {
+        return searchTermCaseSensitivity;
+    }
+
+    public void setSearchTermCaseSensitivity(String searchTermCaseSensitivity) {
+        this.searchTermCaseSensitivity = searchTermCaseSensitivity;
+    }
+
+    public String getSearchTermSeparateWord() {
+        return searchTermSeparateWord;
+    }
+
+    public void setSearchTermSeparateWord(String searchTermSeparateWord) {
+        this.searchTermSeparateWord = searchTermSeparateWord;
+    }
+
+    public String getSearchTermAccuracy() {
+        return searchTermAccuracy;
+    }
+
+    public void setSearchTermAccuracy(String searchTermAccuracy) {
+        this.searchTermAccuracy = searchTermAccuracy;
     }
 
     public void updateSearch() {

--- a/showcase/src/main/webapp/sections/marktext/accuracyLevels.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/accuracyLevels.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MarkText - Accuracy Levels"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates the accuracy property. 'partially' matches if the search term is contained in the text, 'exactly' matches only if the text equals the search term, 'complementarily' matches if the search term contains the text.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/marktext/example-accuracyLevels.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+                ${showcase:getFileContent('/sections/marktext/example-accuracyLevels.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/marktext/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="markText"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/advancedFeatures.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/advancedFeatures.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MarkText - Advanced Features"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates advanced features like multiple search terms, custom styles, and combined properties.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/marktext/example-advancedFeatures.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+                ${showcase:getFileContent('/sections/marktext/example-advancedFeatures.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/marktext/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="markText"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/caseSensitivity.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/caseSensitivity.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MarkText - Case Sensitivity"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates the caseSensitive property. When set to true, search is case-sensitive; when false, it is case-insensitive.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/marktext/example-caseSensitivity.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+                ${showcase:getFileContent('/sections/marktext/example-caseSensitivity.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/marktext/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="markText"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/example-accuracyLevels.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-accuracyLevels.xhtml
@@ -1,0 +1,50 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+
+    <p:messages id="messages" showSummary="true" showDetail="true">
+        <p:autoUpdate/>
+    </p:messages>
+
+    <style>
+        .marktext-highlight {
+            background-color: yellow !important;
+            color: black !important;
+        }
+        mark {
+            background-color: yellow !important;
+            color: black !important;
+        }
+    </style>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="3">
+        <h:outputText value="Search term:"/>
+        <p:inputText id="searchInput" value="#{markTextController.searchTermAccuracy}" placeholder="Enter search term">
+             <p:ajax event="keyup" delay="500" update="partiallyPanel exactlyPanel complementarilyPanel markTextPartially markTextExactly markTextComplementarily"/>
+        </p:inputText>
+        <p:commandButton value="Highlight" update="partiallyPanel exactlyPanel complementarilyPanel markTextPartially markTextExactly markTextComplementarily" icon="pi pi-search"/>
+    </h:panelGrid>
+
+    <h:panelGrid columns="3" style="width: 100%">
+        <p:panel id="partiallyPanel" header="Partially (accuracy='partially')" style="margin-right: 10px">
+            <p>ips sum ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        </p:panel>
+
+        <p:panel id="exactlyPanel" header="Exactly (accuracy='exactly')" style="margin-right: 10px">
+            <p>ips sum ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        </p:panel>
+
+        <p:panel id="complementarilyPanel" header="Complementarily (accuracy='complementarily')">
+            <p>ips sum ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        </p:panel>
+    </h:panelGrid>
+
+    <pe:markText id="markTextPartially" for="partiallyPanel" value="#{markTextController.searchTermAccuracy}" styleClass="marktext-highlight" accuracy="partially"/>
+    <pe:markText id="markTextExactly" for="exactlyPanel" value="#{markTextController.searchTermAccuracy}" styleClass="marktext-highlight" accuracy="exactly"/>
+    <pe:markText id="markTextComplementarily" for="complementarilyPanel" value="#{markTextController.searchTermAccuracy}" styleClass="marktext-highlight" accuracy="complementarily"/>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/example-advancedFeatures.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-advancedFeatures.xhtml
@@ -1,0 +1,48 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+
+    <p:messages id="messages" showSummary="true" showDetail="true">
+        <p:autoUpdate/>
+    </p:messages>
+
+    <style>
+        .marktext-highlight {
+            background-color: yellow !important;
+            color: black !important;
+        }
+        .custom-highlight {
+            background-color: lightgreen !important;
+            color: darkgreen !important;
+            font-weight: bold;
+        }
+        mark {
+            background-color: yellow !important;
+            color: black !important;
+        }
+    </style>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="5">
+        <h:outputText value="Search term 1:"/>
+        <p:inputText id="searchInput1" value="#{markTextController.searchTerm}" placeholder="Enter first search term">
+             <p:ajax event="keyup" delay="500" update="advancedPanel markText1 markText2"/>
+        </p:inputText>
+        <h:outputText value="Search term 2:"/>
+        <p:inputText id="searchInput2" value="#{markTextController.searchTerm2}" placeholder="Enter second search term">
+             <p:ajax event="keyup" delay="500" update="advancedPanel markText1 markText2"/>
+        </p:inputText>
+        <p:commandButton value="Highlight" update="advancedPanel markText1 markText2" icon="pi pi-search"/>
+    </h:panelGrid>
+
+    <p:panel id="advancedPanel" header="Advanced Features - Multiple Terms with Custom Styles and Combined Properties">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </p:panel>
+
+    <pe:markText id="markText1" for="advancedPanel" value="#{markTextController.searchTerm}" styleClass="marktext-highlight" caseSensitive="false" separateWordSearch="true" accuracy="partially"/>
+    <pe:markText id="markText2" for="advancedPanel" value="#{markTextController.searchTerm2}" styleClass="#{markTextController.customStyleClass}" caseSensitive="true" separateWordSearch="false" accuracy="exactly"/>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/example-caseSensitivity.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-caseSensitivity.xhtml
@@ -1,0 +1,45 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+
+    <p:messages id="messages" showSummary="true" showDetail="true">
+        <p:autoUpdate/>
+    </p:messages>
+
+    <style>
+        .marktext-highlight {
+            background-color: yellow !important;
+            color: black !important;
+        }
+        mark {
+            background-color: yellow !important;
+            color: black !important;
+        }
+    </style>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="3">
+        <h:outputText value="Search term:"/>
+        <p:inputText id="searchInput" value="#{markTextController.searchTermCaseSensitivity}" placeholder="Enter search term">
+             <p:ajax event="keyup" delay="500" update="caseSensitivePanel caseInsensitivePanel markTextCaseSensitive markTextCaseInsensitive"/>
+        </p:inputText>
+        <p:commandButton value="Highlight" update="caseSensitivePanel caseInsensitivePanel markTextCaseSensitive markTextCaseInsensitive" icon="pi pi-search"/>
+    </h:panelGrid>
+
+    <h:panelGrid columns="2" style="width: 100%">
+        <p:panel id="caseSensitivePanel" header="Case Sensitive (caseSensitive=true)" style="margin-right: 10px">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </p:panel>
+
+        <p:panel id="caseInsensitivePanel" header="Case Insensitive (caseSensitive=false)">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </p:panel>
+    </h:panelGrid>
+
+    <pe:markText id="markTextCaseSensitive" for="caseSensitivePanel" value="#{markTextController.searchTermCaseSensitivity}" styleClass="marktext-highlight" caseSensitive="true"/>
+    <pe:markText id="markTextCaseInsensitive" for="caseInsensitivePanel" value="#{markTextController.searchTermCaseSensitivity}" styleClass="marktext-highlight" caseSensitive="false"/>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/example-separateWordSearch.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-separateWordSearch.xhtml
@@ -1,0 +1,45 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+
+    <p:messages id="messages" showSummary="true" showDetail="true">
+        <p:autoUpdate/>
+    </p:messages>
+
+    <style>
+        .marktext-highlight {
+            background-color: yellow !important;
+            color: black !important;
+        }
+        mark {
+            background-color: yellow !important;
+            color: black !important;
+        }
+    </style>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="3">
+        <h:outputText value="Search term:"/>
+        <p:inputText id="searchInput" value="#{markTextController.searchTermSeparateWord}" placeholder="Enter search term">
+             <p:ajax event="keyup" delay="500" update="separateWordPanel exactPhrasePanel markTextSeparateWord markTextExactPhrase"/>
+        </p:inputText>
+        <p:commandButton value="Highlight" update="separateWordPanel exactPhrasePanel markTextSeparateWord markTextExactPhrase" icon="pi pi-search"/>
+    </h:panelGrid>
+
+    <h:panelGrid columns="2" style="width: 100%">
+        <p:panel id="separateWordPanel" header="Separate Word Search (separateWordSearch=true)" style="margin-right: 10px">
+            <p>This is a word search example. The word is here, and search is there. Word search together in this sentence.</p>
+        </p:panel>
+
+        <p:panel id="exactPhrasePanel" header="Exact Phrase Search (separateWordSearch=false)">
+            <p>This is a word search example. The word is here, and search is there. Word search together in this sentence.</p>
+        </p:panel>
+    </h:panelGrid>
+
+    <pe:markText id="markTextSeparateWord" for="separateWordPanel" value="#{markTextController.searchTermSeparateWord}" styleClass="marktext-highlight" separateWordSearch="true"/>
+    <pe:markText id="markTextExactPhrase" for="exactPhrasePanel" value="#{markTextController.searchTermSeparateWord}" styleClass="marktext-highlight" separateWordSearch="false"/>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/separateWordSearch.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/separateWordSearch.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MarkText - Separate Word Search"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates the separateWordSearch property. When set to true, searches for each word separately; when false, searches for the exact phrase.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/marktext/example-separateWordSearch.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+                ${showcase:getFileContent('/sections/marktext/example-separateWordSearch.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/marktext/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="markText"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
@@ -7,6 +7,22 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('basicUsage')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/marktext/basicUsage.jsf"/>
+        <p:menuitem value="Case Sensitivity"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('caseSensitivity')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/marktext/caseSensitivity.jsf"/>
+        <p:menuitem value="Separate Word Search"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('separateWordSearch')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/marktext/separateWordSearch.jsf"/>
+        <p:menuitem value="Accuracy Levels"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('accuracyLevels')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/marktext/accuracyLevels.jsf"/>
+        <p:menuitem value="Advanced Features"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('advancedFeatures')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/marktext/advancedFeatures.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
#129 

http://localhost:8080/showcase/sections/marktext/caseSensitivity.jsf

<img width="1578" height="414" alt="image" src="https://github.com/user-attachments/assets/fbb10642-bf0f-430b-b958-969362536008" />

---

http://localhost:8080/showcase/sections/marktext/separateWordSearch.jsf

<img width="1541" height="405" alt="image" src="https://github.com/user-attachments/assets/2a59dae9-1fc5-4504-97ca-41fcb785aed9" />


---

http://localhost:8080/showcase/sections/marktext/accuracyLevels.jsf

<img width="1552" height="421" alt="image" src="https://github.com/user-attachments/assets/edb32e65-2df6-49c3-942e-254178d647b9" />


---

http://localhost:8080/showcase/sections/marktext/advancedFeatures.jsf

<img width="1563" height="427" alt="image" src="https://github.com/user-attachments/assets/9b166bc5-ada0-4eba-a080-9027df8f524c" />
