### PR TITLE
#2274: TimePicker build warning resolution: Replace deprecated StringUtils.equalsIgnoreCase with Strings.CI.equals

### DIFF
--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/TimePickerController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/TimePickerController.java
@@ -35,7 +35,7 @@ import jakarta.faces.event.ActionEvent;
 import jakarta.faces.view.ViewScoped;
 import jakarta.inject.Named;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.primefaces.extensions.event.BeforeShowEvent;
 import org.primefaces.extensions.event.CloseEvent;
 import org.primefaces.extensions.event.TimeSelectEvent;
@@ -163,7 +163,7 @@ public class TimePickerController implements Serializable {
     }
 
     public void changeLocale(final ActionEvent ae) {
-        if (StringUtils.equalsIgnoreCase(locale, "pt_BR")) {
+        if (Strings.CI.equals(locale, "pt_BR")) {
             locale = "en_US";
         }
         else {


### PR DESCRIPTION
#2274 

Deprecated: https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringUtils.html#equalsIgnoreCase(java.lang.CharSequence,java.lang.CharSequence) 

New: https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/Strings.html#equals(java.lang.CharSequence,java.lang.CharSequence)