### PR TITLE
#2276: Fix deprecated RandomUtils method calls by using RandomUtils.secure()

### DIFF
--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/sheet/SheetController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/sheet/SheetController.java
@@ -90,8 +90,8 @@ public class SheetController implements Serializable {
                 final AssetType type) {
         for (int i = 0; i < count; i++) {
             final Asset asset = new Asset();
-            asset.setAssetId(RandomUtils.nextLong());
-            asset.setActive(RandomUtils.nextBoolean());
+            asset.setAssetId(RandomUtils.secure().randomLong());
+            asset.setActive(RandomUtils.secure().randomBoolean());
             asset.setPlatform(platform);
             asset.setPlatformArch(arch);
             asset.setHostName(type.toString().toLowerCase() + i + ".example.lan");
@@ -99,10 +99,10 @@ public class SheetController implements Serializable {
             asset.setIcon("<i class='fas fa-info-circle' style='color:cornflowerblue' />");
             asset.setPurchaseDate(new Date());
             asset.setPurchaseTime(new Date());
-            asset.setValue1(RandomUtils.nextInt(1, 1000));
+            asset.setValue1(RandomUtils.secure().randomInt(1, 1000));
             asset.setPassword(RandomStringUtils.randomAlphabetic(6));
             asset.setPurchasePrice(
-                        BigDecimal.valueOf(RandomUtils.nextDouble(1.11, 999.99) * (RandomUtils.nextBoolean() ? -1 : 1))
+                        BigDecimal.valueOf(RandomUtils.secure().randomDouble(1.11, 999.99) * (RandomUtils.secure().randomBoolean() ? -1 : 1))
                                     .setScale(2, RoundingMode.HALF_UP));
             getAssets().add(asset);
         }

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/sheet/SheetDynamicController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/sheet/SheetDynamicController.java
@@ -55,12 +55,12 @@ public class SheetDynamicController implements Serializable {
     private void addRows(final int count) {
         for (int i = 0; i < count; i++) {
             final DynaSheetRow row = new DynaSheetRow();
-            row.setId(RandomUtils.nextLong());
+            row.setId(RandomUtils.secure().randomLong());
             row.setReadOnly(false);
             final Integer hourOfDay = Integer.valueOf(i);
             hoursOfDay.add(hourOfDay);
             for (int j = 0; j < count; j++) {
-                row.getCells().add(DynaSheetCell.create(Integer.valueOf(j), RandomUtils.nextInt(1, 1000)));
+                row.getCells().add(DynaSheetCell.create(Integer.valueOf(j), RandomUtils.secure().randomInt(1, 1000)));
             }
             getSheetRows().add(row);
         }

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/util/MonacoEditorSettings.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/util/MonacoEditorSettings.java
@@ -152,11 +152,11 @@ public class MonacoEditorSettings {
             return original;
         }
         original = replaceRandomOccurence(original, 20, Pattern.compile("\\d"), //
-                    () -> String.valueOf((char) RandomUtils.nextInt(48, 58)) //
+                    () -> String.valueOf((char) RandomUtils.secure().randomInt(48, 58)) //
         );
 
         original = replaceRandomOccurence(original, 20, Pattern.compile(" "), //
-                    () -> StringUtils.repeat(" ", RandomUtils.nextInt(2, 5)) //
+                    () -> StringUtils.repeat(" ", RandomUtils.secure().randomInt(2, 5)) //
         );
         return original;
     }


### PR DESCRIPTION
#2276 

Replace deprecated RandomUtils.nextLong(), nextBoolean(), nextInt(), and nextDouble() methods with their RandomUtils.secure() equivalents in SheetController, SheetDynamicController, and MonacoEditorSettings classes.