### PR TITLE
Fix #2283: Resolve CI warnings for missing image resources and deprecatedated CSS import

### DIFF
--- a/showcase/pom.xml
+++ b/showcase/pom.xml
@@ -246,6 +246,12 @@
                                     <includes>
                                         <include>**/*.css</include>
                                         <include>**/*.js</include>
+                                        <include>**/*.png</include>
+                                        <include>**/*.jpg</include>
+                                        <include>**/*.jpeg</include>
+                                        <include>**/*.gif</include>
+                                        <include>**/*.ico</include>
+                                        <include>**/*.bmp</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/showcase/src/main/webapp/resources/syntaxhighlighter/styles/darkula.css
+++ b/showcase/src/main/webapp/resources/syntaxhighlighter/styles/darkula.css
@@ -1,6 +1,0 @@
-/*
-  Deprecated due to a typo in the name and left here for compatibility purpose only.
-  Please use darcula.css instead.
-*/
-
-@import url('darcula.css');


### PR DESCRIPTION
Fix #2283