### PR TITLE
#2295: Search component - Support synonyms and update showcase

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkText.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkText.java
@@ -50,7 +50,6 @@ import com.google.gson.reflect.TypeToken;
 @ResourceDependency(library = "primefaces", name = "core.js")
 @ResourceDependency(library = "primefaces", name = "components.js")
 @ResourceDependency(library = Constants.LIBRARY, name = "mark/mark.js")
-@ResourceDependency(library = Constants.LIBRARY, name = "mark/marktext.js")
 public class MarkText extends MarkTextBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.MarkText";

--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
@@ -51,7 +51,8 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, Cl
         caseSensitive,
         separateWordSearch,
         accuracy,
-        actionListener
+        actionListener,
+        synonyms
         //@formatter:on
     }
 
@@ -134,5 +135,13 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, Cl
 
     public void setActionListener(final MethodExpression actionListener) {
         getStateHelper().put(PropertyKeys.actionListener, actionListener);
+    }
+
+    public Object getSynonyms() {
+        return getStateHelper().eval(PropertyKeys.synonyms, null);
+    }
+
+    public void setSynonyms(final Object synonyms) {
+        getStateHelper().put(PropertyKeys.synonyms, synonyms);
     }
 }

--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
@@ -31,6 +31,8 @@ import org.primefaces.extensions.util.Attrs;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.WidgetBuilder;
 
+import com.google.gson.Gson;
+
 /**
  * <code>MarkText</code> component.
  *
@@ -73,6 +75,9 @@ public class MarkTextRenderer extends CoreRenderer {
         wb.attr("accuracy", markText.getAccuracy());
         wb.attr("className", markText.getStyleClass());
         wb.attr("hasActionListener", markText.getActionListener() != null);
+        if (markText.getSynonyms() != null) {
+            wb.nativeAttr("synonyms", new Gson().toJson(markText.getSynonyms()));
+        }
 
         encodeClientBehaviors(context, markText);
 

--- a/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -3198,6 +3198,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Synonyms to search for. Can be a Map or a JSON string.]]>
+            </description>
+            <name>synonyms</name>
+            <required>false</required>
+            <type>java.lang.Object</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Method expression for action listener called when highlighting occurs.]]>
             </description>
             <name>actionListener</name>

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
@@ -18,6 +18,7 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
         this.caseSensitive = cfg.caseSensitive;
         this.separateWordSearch = cfg.separateWordSearch;
         this.accuracy = cfg.accuracy;
+        this.synonyms = cfg.synonyms ? (typeof cfg.synonyms === 'string' ? JSON.parse(cfg.synonyms) : cfg.synonyms) : {};
 
         this.markInstance = null;
 
@@ -70,6 +71,7 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
                     separateWordSearch: this.separateWordSearch,
                     accuracy: this.accuracy,
                     className: this.cfg.className,
+                    synonyms: this.synonyms,
                     each: function(element) {
                         var term = $(element).text();
                         if (matchedTerms.indexOf(term) === -1) {

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/MarkTextController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/MarkTextController.java
@@ -19,7 +19,7 @@
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  *  THE SOFTWARE.
  */
-package org.primefaces.extensions.showcase.controller;
+package org.primefaces.extensions.showcase.controller.marktext;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/SynonymsMarkTextController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/SynonymsMarkTextController.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2011-2025 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.marktext;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import org.primefaces.extensions.event.MarkEvent;
+import org.primefaces.extensions.model.marktext.MarkPosition;
+
+/**
+ * Synonyms MarkText Controller.
+ *
+ * @author jxmai
+ */
+@Named
+@ViewScoped
+public class SynonymsMarkTextController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String searchTerm = "one";
+
+    private Map<String, String> synonyms = new HashMap<String, String>() {
+        {
+            put("one", "1");
+            put("two", "2");
+            put("three", "3");
+            put("four", "4");
+            put("five", "5");
+        }
+    };
+
+    private String processedText = "Counting is easy: one, two, three, four, five. "
+                + "Numbers: 1, 2, 3, 4, 5. "
+                + "You can use either words or digits: one (1), two (2), three (3). "
+                + "This demonstrates synonyms highlighting both ways.";
+
+    private List<String> lastMatchedTerms = new ArrayList<>();
+
+    private List<MarkPosition> lastPositions = new ArrayList<>();
+
+    private String lastMatchedTermsJson;
+
+    private String lastPositionsJson;
+
+    public String getSearchTerm() {
+        return searchTerm;
+    }
+
+    public void setSearchTerm(String searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    public Map<String, String> getSynonyms() {
+        return synonyms;
+    }
+
+    public void setSynonyms(Map<String, String> synonyms) {
+        this.synonyms = synonyms;
+    }
+
+    public String getProcessedText() {
+        return processedText;
+    }
+
+    public void setProcessedText(String processedText) {
+        this.processedText = processedText;
+    }
+
+    public List<String> getLastMatchedTerms() {
+        return lastMatchedTerms;
+    }
+
+    public List<MarkPosition> getLastPositions() {
+        return lastPositions;
+    }
+
+    public void onHighlight(MarkEvent event) {
+        this.lastMatchedTerms = event.getMatchedTerms();
+        this.lastPositions = event.getPositions();
+
+        this.lastMatchedTermsJson = lastMatchedTerms.toString();
+        this.lastPositionsJson = lastPositions.stream()
+                    .map(MarkPosition::toString)
+                    .collect(Collectors.joining(", "));
+
+        FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Mark Event Triggered",
+                                "Found " + lastMatchedTerms.size() + " matched terms and " + lastPositions.size() + " positions."));
+    }
+
+    public String getLastMatchedTermsJson() {
+        return lastMatchedTermsJson;
+    }
+
+    public void setLastMatchedTermsJson(String lastMatchedTermsJson) {
+        this.lastMatchedTermsJson = lastMatchedTermsJson;
+    }
+
+    public String getLastPositionsJson() {
+        return lastPositionsJson;
+    }
+
+    public void setLastPositionsJson(String lastPositionsJson) {
+        this.lastPositionsJson = lastPositionsJson;
+    }
+}

--- a/showcase/src/main/webapp/sections/marktext/accuracyLevels.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/accuracyLevels.xhtml
@@ -21,7 +21,7 @@
                 ${showcase:getFileContent('/sections/marktext/example-accuracyLevels.xhtml')}
             </ui:define>
             <ui:define name="contentTab2">
-                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/MarkTextController.java')}
             </ui:define>
         </ui:decorate>
     </ui:define>

--- a/showcase/src/main/webapp/sections/marktext/advancedFeatures.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/advancedFeatures.xhtml
@@ -21,7 +21,7 @@
                 ${showcase:getFileContent('/sections/marktext/example-advancedFeatures.xhtml')}
             </ui:define>
             <ui:define name="contentTab2">
-                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/MarkTextController.java')}
             </ui:define>
         </ui:decorate>
     </ui:define>

--- a/showcase/src/main/webapp/sections/marktext/basicUsage.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/basicUsage.xhtml
@@ -21,7 +21,7 @@
                 ${showcase:getFileContent('/sections/marktext/example-basicUsage.xhtml')}
             </ui:define>
             <ui:define name="contentTab2">
-                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/MarkTextController.java')}
             </ui:define>
         </ui:decorate>
     </ui:define>

--- a/showcase/src/main/webapp/sections/marktext/example-synonyms.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-synonyms.xhtml
@@ -1,0 +1,40 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+
+    <p:messages id="messages" showSummary="true" showDetail="true">
+        <p:autoUpdate/>
+    </p:messages>
+
+    <style>
+        .marktext-highlight {
+            background-color: yellow !important;
+            color: black !important;
+        }
+        mark {
+            background-color: yellow !important;
+            color: black !important;
+        }
+    </style>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="3">
+        <h:outputText value="Search term:"/>
+        <p:inputText id="searchInput" value="#{synonymsMarkTextController.searchTerm}" placeholder="Enter search term">
+             <p:ajax event="keyup" delay="500" update="searchContainer markText"/>
+        </p:inputText>
+        <p:commandButton value="Highlight" update="searchContainer markText" icon="pi pi-search"/>
+    </h:panelGrid>
+
+    <p:panel id="searchContainer" header="Searchable Content" style="margin-top: 20px">
+        <h:panelGroup id="searchContent" layout="block">
+            #{synonymsMarkTextController.processedText}
+        </h:panelGroup>
+    </p:panel>
+
+    <pe:markText id="markText" for="searchContent" value="#{synonymsMarkTextController.searchTerm}" synonyms="#{synonymsMarkTextController.synonyms}" styleClass="marktext-highlight" actionListener="#{synonymsMarkTextController.onHighlight}"/>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/separateWordSearch.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/separateWordSearch.xhtml
@@ -21,7 +21,7 @@
                 ${showcase:getFileContent('/sections/marktext/example-separateWordSearch.xhtml')}
             </ui:define>
             <ui:define name="contentTab2">
-                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/MarkTextController.java')}
             </ui:define>
         </ui:decorate>
     </ui:define>

--- a/showcase/src/main/webapp/sections/marktext/synonyms.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/synonyms.xhtml
@@ -2,26 +2,28 @@
       xmlns:h="jakarta.faces.html"
       xmlns:f="jakarta.faces.core"
       xmlns:ui="jakarta.faces.facelets"
-      xmlns:showcase="primefaces.extensions.showcase">
+      xmlns:showcase="primefaces.extensions.showcase"
+      xmlns:pe="primefaces.extensions">
 <ui:composition template="/templates/showcaseLayout.xhtml">
     <ui:define name="centerContent">
         <f:facet name="header">
-            <h:outputText value="MarkText - Case Sensitivity"/>
+            <h:outputText value="MarkText - Synonyms"/>
         </f:facet>
         <h:panelGroup layout="block" styleClass="centerContent">
-            Demonstrates the caseSensitive property. When set to true, search is case-sensitive; when false, it is case-insensitive.
+            Demonstrates the synonyms property, which allows highlighting synonymous terms bidirectionally. 
+            For example, searching for "one" will also highlight "1", and vice versa, based on the provided synonyms map.
         </h:panelGroup>
 
         <h:panelGroup layout="block" styleClass="centerExample">
-            <ui:include src="/sections/marktext/example-caseSensitivity.xhtml"/>
+            <ui:include src="/sections/marktext/example-synonyms.xhtml"/>
         </h:panelGroup>
 
         <ui:decorate template="/templates/twoTabsDecorator.xhtml">
             <ui:define name="contentTab1">
-                ${showcase:getFileContent('/sections/marktext/example-caseSensitivity.xhtml')}
+                ${showcase:getFileContent('/sections/marktext/example-synonyms.xhtml')}
             </ui:define>
             <ui:define name="contentTab2">
-                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/MarkTextController.java')}
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/SynonymsMarkTextController.java')}
             </ui:define>
         </ui:decorate>
     </ui:define>

--- a/showcase/src/main/webapp/sections/marktext/updateSearch.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/updateSearch.xhtml
@@ -21,7 +21,7 @@
                 ${showcase:getFileContent('/sections/marktext/example-updateSearch.xhtml')}
             </ui:define>
             <ui:define name="contentTab2">
-                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MarkTextController.java')}
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/MarkTextController.java')}
             </ui:define>
         </ui:decorate>
     </ui:define>

--- a/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
@@ -23,6 +23,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('updateSearch')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/marktext/updateSearch.jsf"/>
+        <p:menuitem value="Synonyms"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('synonyms')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/marktext/synonyms.jsf"/>
         <p:menuitem value="Advanced Features"
                     styleClass="#{navigationContext.getMenuitemStyleClass('advancedFeatures')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"


### PR DESCRIPTION
Resolve: #2295 

Local showcase demo: 

<img width="1462" height="359" alt="image" src="https://github.com/user-attachments/assets/a19577ac-4fad-4289-89fb-8dba7927f6b2" />


<img width="1465" height="373" alt="image" src="https://github.com/user-attachments/assets/9921c4cf-c8af-4ed2-bd58-d0b35d152a73" />




We can define synonyms map behind the scene as a map

```java
 private Map<String, String> synonyms = new HashMap<String, String>() {
        {
            put("one", "1");
            put("two", "2");
            put("three", "3");
            put("four", "4");
            put("five", "5");
        }
    };
```