### PR TITLE
#2309: CDK: Fix InputHolder complication errors (Temporary rename to match upstream until those components migrate to CDK)

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/clockpicker/ClockPicker.java
+++ b/core/src/main/java/org/primefaces/extensions/component/clockpicker/ClockPicker.java
@@ -93,13 +93,13 @@ public class ClockPicker extends AbstractPrimeHtmlInputText implements Widget, I
     }
 
     @Override
-    public String getLabelledBy() {
-        return (String) getStateHelper().get("labelledby");
+    public String getAriaLabelledBy() {
+        return (String) getStateHelper().get("ariaLabelledBy");
     }
 
     @Override
-    public void setLabelledBy(String labelledBy) {
-        getStateHelper().put("labelledby", labelledBy);
+    public void setAriaLabelledBy(String ariaLabelledBy) {
+        getStateHelper().put("ariaLabelledBy", ariaLabelledBy);
     }
 
     @Override

--- a/core/src/main/java/org/primefaces/extensions/component/inputotp/InputOtp.java
+++ b/core/src/main/java/org/primefaces/extensions/component/inputotp/InputOtp.java
@@ -64,7 +64,8 @@ public class InputOtp extends AbstractPrimeHtmlInputText implements Widget, Inpu
     public static final String INPUT_SUFFIX = "_input";
     public static final String HIDDEN_SUFFIX = "_hidden";
 
-    // disabled, readonly, style, styleClass, size, placeholder handled by component renderer
+    // disabled, readonly, style, styleClass, size, placeholder handled by component
+    // renderer
     public static final List<String> INPUT_OTP_ATTRIBUTES_WITHOUT_EVENTS = List.of(
                 "accesskey",
                 "alt",
@@ -110,13 +111,13 @@ public class InputOtp extends AbstractPrimeHtmlInputText implements Widget, Inpu
     }
 
     @Override
-    public String getLabelledBy() {
-        return (String) getStateHelper().get("labelledby");
+    public String getAriaLabelledBy() {
+        return (String) getStateHelper().get("ariaLabelledBy");
     }
 
     @Override
-    public void setLabelledBy(final String labelledBy) {
-        getStateHelper().put("labelledby", labelledBy);
+    public void setAriaLabelledBy(final String ariaLabelledBy) {
+        getStateHelper().put("ariaLabelledBy", ariaLabelledBy);
     }
 
     @Override

--- a/core/src/main/java/org/primefaces/extensions/component/inputphone/InputPhone.java
+++ b/core/src/main/java/org/primefaces/extensions/component/inputphone/InputPhone.java
@@ -54,7 +54,8 @@ import org.primefaces.util.LangUtils;
 @ResourceDependency(library = "primefaces", name = "core.js")
 @ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "inputphone/inputphone.css")
 @ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "inputphone/inputphone.js")
-public class InputPhone extends AbstractPrimeHtmlInputText implements Widget, InputHolder, MixedClientBehaviorHolder, RTLAware {
+public class InputPhone extends AbstractPrimeHtmlInputText
+            implements Widget, InputHolder, MixedClientBehaviorHolder, RTLAware {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.InputPhone";
     public static final String COMPONENT_FAMILY = "org.primefaces.extensions.component";
@@ -66,7 +67,8 @@ public class InputPhone extends AbstractPrimeHtmlInputText implements Widget, In
     public static final String INPUT_SUFFIX = "_input";
 
     private static final List<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList(EVENT_COUNTRY_SELECT);
-    private static final Collection<String> EVENT_NAMES = LangUtils.concat(AbstractPrimeHtmlInputText.EVENT_NAMES, UNOBSTRUSIVE_EVENT_NAMES);
+    private static final Collection<String> EVENT_NAMES = LangUtils.concat(AbstractPrimeHtmlInputText.EVENT_NAMES,
+                UNOBSTRUSIVE_EVENT_NAMES);
 
     // @formatter:off
     @SuppressWarnings("java:S115")
@@ -146,13 +148,13 @@ public class InputPhone extends AbstractPrimeHtmlInputText implements Widget, In
     }
 
     @Override
-    public String getLabelledBy() {
-        return (String) getStateHelper().get("labelledby");
+    public String getAriaLabelledBy() {
+        return (String) getStateHelper().get("ariaLabelledBy");
     }
 
     @Override
-    public void setLabelledBy(final String labelledBy) {
-        getStateHelper().put("labelledby", labelledBy);
+    public void setAriaLabelledBy(final String ariaLabelledBy) {
+        getStateHelper().put("ariaLabelledBy", ariaLabelledBy);
     }
 
     @Override
@@ -344,7 +346,8 @@ public class InputPhone extends AbstractPrimeHtmlInputText implements Widget, In
 
             if (EVENT_COUNTRY_SELECT.equals(eventName)) {
                 final Country selectedCountry = getCountry(getClientId(context), params);
-                final SelectEvent<Country> selectEvent = new SelectEvent<>(this, ajaxBehaviorEvent.getBehavior(), selectedCountry);
+                final SelectEvent<Country> selectEvent = new SelectEvent<>(this, ajaxBehaviorEvent.getBehavior(),
+                            selectedCountry);
                 selectEvent.setPhaseId(ajaxBehaviorEvent.getPhaseId());
                 super.queueEvent(selectEvent);
             }

--- a/core/src/main/java/org/primefaces/extensions/component/timepicker/TimePicker.java
+++ b/core/src/main/java/org/primefaces/extensions/component/timepicker/TimePicker.java
@@ -77,7 +77,8 @@ public class TimePicker extends AbstractPrimeHtmlInputText implements Widget, In
 
     private static final List<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList(BeforeShowEvent.NAME,
                 TimeSelectEvent.NAME, CloseEvent.NAME);
-    private static final Collection<String> EVENT_NAMES = LangUtils.concat(AbstractPrimeHtmlInputText.EVENT_NAMES, UNOBSTRUSIVE_EVENT_NAMES);
+    private static final Collection<String> EVENT_NAMES = LangUtils.concat(AbstractPrimeHtmlInputText.EVENT_NAMES,
+                UNOBSTRUSIVE_EVENT_NAMES);
 
     private final Map<String, AjaxBehaviorEvent> customEvents = new HashMap<>();
     private Locale appropriateLocale;
@@ -136,13 +137,13 @@ public class TimePicker extends AbstractPrimeHtmlInputText implements Widget, In
     }
 
     @Override
-    public String getLabelledBy() {
-        return (String) getStateHelper().get("labelledby");
+    public String getAriaLabelledBy() {
+        return (String) getStateHelper().get("ariaLabelledBy");
     }
 
     @Override
-    public void setLabelledBy(String labelledBy) {
-        getStateHelper().put("labelledby", labelledBy);
+    public void setAriaLabelledBy(String ariaLabelledBy) {
+        getStateHelper().put("ariaLabelledBy", ariaLabelledBy);
     }
 
     @Override
@@ -437,7 +438,8 @@ public class TimePicker extends AbstractPrimeHtmlInputText implements Widget, In
         if (isValid()) {
             for (final Entry<String, AjaxBehaviorEvent> entry : customEvents.entrySet()) {
                 final AjaxBehaviorEvent behaviorEvent = entry.getValue();
-                final TimeSelectEvent<Object> timeSelectEvent = new TimeSelectEvent<>(this, behaviorEvent.getBehavior(), getValue());
+                final TimeSelectEvent<Object> timeSelectEvent = new TimeSelectEvent<>(this, behaviorEvent.getBehavior(),
+                            getValue());
 
                 if (behaviorEvent.getPhaseId().equals(PhaseId.APPLY_REQUEST_VALUES)) {
                     timeSelectEvent.setPhaseId(PhaseId.PROCESS_VALIDATIONS);


### PR DESCRIPTION
Resolve: #2309

Following the changes: https://github.com/primefaces/primefaces/commit/e68ee54e824b55900b36e8b2f0d84c64a8164101

Those methods can be removed once migrate to CDK as recommended here: https://github.com/primefaces-extensions/primefaces-extensions/pull/2307#issuecomment-3923151182, but for now we should ensure the build is working.