### PR TITLE
#2343: Add dependency on aggregated primefaces-extensions.css to ensure orgchart styles load after resource aggregation

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChart.java
+++ b/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChart.java
@@ -32,6 +32,7 @@ import jakarta.faces.event.FacesEvent;
 import org.primefaces.cdk.api.FacesComponentInfo;
 import org.primefaces.extensions.event.OrgChartClickEvent;
 import org.primefaces.extensions.event.OrgChartDropEvent;
+import org.primefaces.extensions.util.Constants;
 
 /**
  * <code>orgchart</code> component.
@@ -45,10 +46,10 @@ import org.primefaces.extensions.event.OrgChartDropEvent;
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
-@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "primefaces-extensions.js")
-@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "orgchart/orgchart.js")
-@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "orgchart/orgchart.css")
-@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "orgchart/style.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "orgchart/orgchart.js")
+@ResourceDependency(library = Constants.LIBRARY, name = "orgchart/orgchart.css")
+@ResourceDependency(library = Constants.LIBRARY, name = "primefaces-extensions.css")
 public class OrgChart extends OrgChartBaseImpl {
 
     public static final String STYLE_CLASS = "ui-orgchart ";


### PR DESCRIPTION
Fix: #2343 

Local showcase test drive: 
http://localhost:8080/showcase/sections/orgchart/colorCoded.jsf


<img width="749" height="390" alt="image" src="https://github.com/user-attachments/assets/8d16c743-bc92-454e-93f2-32fea74735ec" />


If style wasn't loaded, the orgchart would be misaligned. This indicates the fix is working. No related errors on console after the changes.