### PR TITLE
Orgchart: resource optimization

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -221,6 +221,7 @@
                                 <include>timer/**</include>
                                 <include>tooltip/**</include>
                                 <include>waypoint/**</include>
+                                <include>orgchart/**</include>
                             </includes>
                             <aggregations>
                                 <aggregation>
@@ -237,7 +238,6 @@
                                 <include>codescanner/**</include>
                                 <include>markdowneditor/**</include>
                                 <include>suneditor/**</include>
-                                <include>orgchart/**</include>
                             </includes>
                             <aggregations>
                                 <aggregation>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -221,7 +221,6 @@
                                 <include>timer/**</include>
                                 <include>tooltip/**</include>
                                 <include>waypoint/**</include>
-                                <include>orgchart/**</include>
                             </includes>
                             <aggregations>
                                 <aggregation>
@@ -244,6 +243,21 @@
                                     <inputDir>${resources.dir.compressed}</inputDir>
                                     <subDirMode>true</subDirMode>
                                     <withoutCompress>true</withoutCompress>
+                                </aggregation>
+                            </aggregations>
+                        </resourcesSet>
+                        <resourcesSet>
+                            <includes>
+                                <include>orgchart/**</include>
+                            </includes>
+                            <excludes>
+                                <exclude>orgchart/2-jspdf.js</exclude>
+                            </excludes>
+                            <aggregations>
+                                <aggregation>
+                                    <inputDir>${resources.dir.compressed}</inputDir>
+                                    <subDirMode>true</subDirMode>
+                                    <withoutCompress>${withoutCompress}</withoutCompress>
                                 </aggregation>
                             </aggregations>
                         </resourcesSet>


### PR DESCRIPTION
Previously we disabled orgchart compression entirely due to: https://github.com/primefaces-extensions/primefaces-extensions/pull/2233#issuecomment-3752693284

We can optimize better by excluding jspdf and compress the rest of resources.