### PR TITLE
#2371: Search (MarkText) - remove obsolete actionListener API and use mark behavior listener in showcase

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
@@ -21,7 +21,6 @@
  */
 package org.primefaces.extensions.component.marktext;
 
-import jakarta.el.MethodExpression;
 import jakarta.faces.component.UIComponentBase;
 
 import org.primefaces.cdk.api.FacesBehaviorEvent;
@@ -74,9 +73,6 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, St
 
     @Property(description = "Search accuracy level: 'partially', 'complementarily', or 'exactly'.", defaultValue = "partially")
     public abstract String getAccuracy();
-
-    @Property(description = "Server-side listener method for mark events.")
-    public abstract MethodExpression getActionListener();
 
     @Property(description = "Map of synonyms for term matching.")
     public abstract Object getSynonyms();

--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
@@ -76,7 +76,6 @@ public class MarkTextRenderer extends CoreRenderer<MarkText> {
         wb.attr("accuracy", component.getAccuracy());
         wb.attr("acrossElements", component.getAcrossElements());
         wb.attr("className", component.getStyleClass());
-        wb.attr("hasActionListener", component.getActionListener() != null);
         if (component.getSynonyms() != null) {
             wb.nativeAttr("synonyms", new Gson().toJson(component.getSynonyms()));
         }

--- a/showcase/src/main/webapp/sections/marktext/example-synonyms.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-synonyms.xhtml
@@ -35,6 +35,8 @@
         </h:panelGroup>
     </p:panel>
 
-    <pe:markText id="markText" for="searchContent" value="#{synonymsMarkTextController.searchTerm}" synonyms="#{synonymsMarkTextController.synonyms}" styleClass="marktext-highlight" actionListener="#{synonymsMarkTextController.onHighlight}"/>
+    <pe:markText id="markText" for="searchContent" value="#{synonymsMarkTextController.searchTerm}" synonyms="#{synonymsMarkTextController.synonyms}" styleClass="marktext-highlight">
+        <p:ajax event="mark" listener="#{synonymsMarkTextController.onHighlight}" update="messages"/>
+    </pe:markText>
     <!-- EXAMPLE-SOURCE-END -->
 </ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/example-updateSearch.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-updateSearch.xhtml
@@ -33,7 +33,7 @@
         <p>#{markTextController.processedTextSecondPart}</p>
     </p:panel>
 
-    <p:panel id="backendDataPanel" header="Backend Data from ActionListener" style="margin-top: 20px">
+    <p:panel id="backendDataPanel" header="Backend Data from Mark Event Listener" style="margin-top: 20px">
         <h:outputText value="Last Matched Terms: #{empty markTextController.lastMatchedTerms ? 'No data received yet' : markTextController.lastMatchedTerms}" />
         <br/>
         <h:outputText value="Last Positions: #{empty markTextController.lastPositions ? 'No data received yet' : markTextController.lastPositions}" />


### PR DESCRIPTION
Fix #2371 

https://primefaces-extensions-showcase-55pq8.ondigitalocean.app/sections/marktext/synonyms.jsf

<img width="748" height="496" alt="image" src="https://github.com/user-attachments/assets/bbdb4798-dd6c-4e80-82ed-6c334d303fa5" />


vs

http://localhost:8080/showcase/sections/marktext/synonyms.jsf

<img width="1213" height="475" alt="image" src="https://github.com/user-attachments/assets/19031731-395a-49b0-bf2c-55652278cabb" />
