### PR TITLE
#2385: OrgChart: Support Filter with minimal configuration

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartBase.java
@@ -111,6 +111,9 @@ public abstract class OrgChartBase extends UIData implements Widget, StyleAware 
     @Property(description = "The node title property name.", defaultValue = "name")
     public abstract String getNodeTitle();
 
+    @Property(description = "Render built-in filter controls for client-side node filtering.", defaultValue = "false")
+    public abstract Boolean getFilterable();
+
     @Property(description = "Name of javascript function to extend the widget.")
     public abstract String getExtender();
 }

--- a/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartRenderer.java
@@ -172,6 +172,7 @@ public class OrgChartRenderer extends CoreRenderer<OrgChart> {
         wb.attr("zoomoutLimit", component.getZoomoutLimit());
         wb.attr("verticalDepth", component.getVerticalDepth());
         wb.attr("nodeTitle", component.getNodeTitle());
+        wb.attr("filterable", component.getFilterable(), false);
         wb.nativeAttr("extender", component.getExtender());
         wb.attr("data", data);
 

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/3-orgchart-widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/3-orgchart-widget.js
@@ -4,6 +4,19 @@
  * @author jxmai
  * @since 6.3
  */
+const PFE_ORGCHART_FILTER_DEFAULTS = Object.freeze({
+    placeholder: 'Search by name or title',
+    applyLabel: 'Filter',
+    clearLabel: 'Clear',
+    emptyAlert: 'Please type key word firstly.'
+});
+
+const PFE_ORGCHART_FILTER_ROLES = Object.freeze({
+    input: 'filter-input',
+    apply: 'filter-apply',
+    clear: 'filter-clear'
+});
+
 PrimeFaces.widget.ExtOrgChart = class extends PrimeFaces.widget.BaseWidget {
 
     /**
@@ -15,6 +28,7 @@ PrimeFaces.widget.ExtOrgChart = class extends PrimeFaces.widget.BaseWidget {
     init(cfg) {
         super.init(cfg);
         this.id = cfg.id;
+        this.filterEventNamespace = '.pfeOrgChartFilter_' + this.id.replace(/[^A-Za-z0-9_]/g, '_');
 
         // user extension to configure plugin
         var extender = this.cfg.extender;
@@ -44,6 +58,228 @@ PrimeFaces.widget.ExtOrgChart = class extends PrimeFaces.widget.BaseWidget {
         this.orgchart = this.jq.orgchart(opts);
 
         this._bindEvents();
+        this._bindFilterControls();
+    }
+
+    /**
+     * Filters chart nodes by keyword using the same behavior as the official OrgChart filter-node demo.
+     * Matching nodes and their ancestor chain are kept visible.
+     *
+     * @param {string} keyWord The keyword used to match node text.
+     * @param {boolean} [showAlert=true] Whether to show an alert for empty keyword.
+     * @returns {boolean} `true` if a filter was applied, otherwise `false`.
+     */
+    filterNodes(keyWord, showAlert = true) {
+        var normalizedKeyword = (keyWord || '').trim().toLowerCase();
+        if (!normalizedKeyword.length) {
+            if (showAlert) {
+                window.alert(PFE_ORGCHART_FILTER_DEFAULTS.emptyAlert);
+            }
+            return false;
+        }
+
+        this.clearFilter();
+
+        var $chart = this.getOrgChartRoot();
+        $chart.addClass('noncollapsable');
+
+        $chart.find('.node').filter(function(index, node) {
+            return $(node).text().toLowerCase().indexOf(normalizedKeyword) > -1;
+        }).addClass('matched')
+            .closest('.hierarchy').parents('.hierarchy').children('.node').addClass('retained');
+
+        $chart.find('.matched,.retained').each(function(index, node) {
+            $(node).removeClass('slide-up')
+                .closest('.nodes').removeClass('hidden')
+                .siblings('.hierarchy').removeClass('isChildrenCollapsed');
+
+            var $unmatched = $(node).closest('.hierarchy').siblings().find('.node:first:not(.matched,.retained)')
+                .closest('.hierarchy').addClass('hidden');
+
+            $unmatched.parent('.nodes').siblings('.node').addClass('isSiblingsCollapsed');
+        });
+
+        $chart.find('.matched').each(function(index, node) {
+            if (!$(node).siblings('.nodes').find('.matched').length) {
+                $(node).siblings('.nodes').addClass('hidden')
+                    .parent().addClass('isChildrenCollapsed');
+            }
+        });
+
+        this._loopVisibleHierarchies($chart.find('.hierarchy:first'));
+        return true;
+    }
+
+    /**
+     * Clears node filtering results and restores the chart to its normal collapsible state.
+     */
+    clearFilter() {
+        var $chart = this.getOrgChartRoot();
+        $chart.removeClass('noncollapsable')
+            .find('.node').removeClass('matched retained isSiblingsCollapsed')
+            .end().find('.hidden, .isChildrenCollapsed, .first-shown, .last-shown')
+            .removeClass('hidden isChildrenCollapsed first-shown last-shown')
+            .end().find('.slide-up, .slide-left, .slide-right').removeClass('slide-up slide-right slide-left');
+    }
+
+    // @override
+    refresh(cfg) {
+        this._unbindFilterControls();
+        super.refresh(cfg);
+    }
+
+    // @override
+    destroy() {
+        this._unbindFilterControls();
+        super.destroy();
+    }
+
+    /**
+     * Returns the inner chart root (`.orgchart`) used by the underlying plugin.
+     *
+     * @returns {JQuery} The chart root element.
+     */
+    getOrgChartRoot() {
+        return this.jq.children('.orgchart').first();
+    }
+
+    _ensureFilterControls() {
+        if (this.cfg.filterable !== true) {
+            return null;
+        }
+
+        var inputId = this.id + '_filterInput';
+        var filterButtonId = this.id + '_filterButton';
+        var clearFilterButtonId = this.id + '_clearFilterButton';
+
+        var $panel = this.jq.children('.pfe-orgchart-filter-controls');
+        if (!$panel.length) {
+            $panel = $('<div>', {
+                'class': 'pfe-orgchart-filter-controls'
+            }).prependTo(this.jq);
+        }
+
+        var inputRoleSelector = '[data-pfe-role="' + PFE_ORGCHART_FILTER_ROLES.input + '"]';
+        var applyRoleSelector = '[data-pfe-role="' + PFE_ORGCHART_FILTER_ROLES.apply + '"]';
+        var clearRoleSelector = '[data-pfe-role="' + PFE_ORGCHART_FILTER_ROLES.clear + '"]';
+
+        var $input = $panel.children(inputRoleSelector);
+        if (!$input.length) {
+            $input = $('<input>', {
+                id: inputId,
+                type: 'text',
+                'class': 'pfe-orgchart-filter-input',
+                'data-pfe-role': PFE_ORGCHART_FILTER_ROLES.input,
+                placeholder: PFE_ORGCHART_FILTER_DEFAULTS.placeholder
+            }).appendTo($panel);
+        }
+
+        var $filterButton = $panel.children(applyRoleSelector);
+        if (!$filterButton.length) {
+            $filterButton = $('<button>', {
+                id: filterButtonId,
+                type: 'button',
+                'class': 'pfe-orgchart-filter-button',
+                'data-pfe-role': PFE_ORGCHART_FILTER_ROLES.apply,
+                text: PFE_ORGCHART_FILTER_DEFAULTS.applyLabel
+            }).appendTo($panel);
+        }
+
+        var $clearButton = $panel.children(clearRoleSelector);
+        if (!$clearButton.length) {
+            $clearButton = $('<button>', {
+                id: clearFilterButtonId,
+                type: 'button',
+                'class': 'pfe-orgchart-filter-button',
+                'data-pfe-role': PFE_ORGCHART_FILTER_ROLES.clear,
+                text: PFE_ORGCHART_FILTER_DEFAULTS.clearLabel
+            }).appendTo($panel);
+        }
+
+        return {
+            filterInput: $input,
+            filterButton: $filterButton,
+            clearFilterButton: $clearButton
+        };
+    }
+
+    _bindFilterControls() {
+        var controls = this._ensureFilterControls();
+        if (!controls) {
+            return;
+        }
+
+        var $this = this;
+        var filterInput = controls.filterInput;
+        var filterButton = controls.filterButton;
+        var clearFilterButton = controls.clearFilterButton;
+        var filterOnEnter = true;
+        var clearOnBackspace = true;
+
+        if (!filterInput.length && !filterButton.length && !clearFilterButton.length) {
+            return;
+        }
+
+        if (filterButton.length) {
+            filterButton.off('click' + this.filterEventNamespace).on('click' + this.filterEventNamespace, function(event) {
+                event.preventDefault();
+                $this.filterNodes(filterInput.val(), true);
+                return false;
+            });
+        }
+
+        if (clearFilterButton.length) {
+            clearFilterButton.off('click' + this.filterEventNamespace).on('click' + this.filterEventNamespace, function(event) {
+                event.preventDefault();
+                $this.clearFilter();
+                if (filterInput.length) {
+                    filterInput.val('');
+                }
+                return false;
+            });
+        }
+
+        if (filterInput.length && (filterOnEnter || clearOnBackspace)) {
+            filterInput.off('keyup' + this.filterEventNamespace).on('keyup' + this.filterEventNamespace, function(event) {
+                if (filterOnEnter && event.which === 13) {
+                    $this.filterNodes(this.value, false);
+                    event.preventDefault();
+                    return false;
+                }
+
+                if (clearOnBackspace && event.which === 8 && this.value.length === 0) {
+                    $this.clearFilter();
+                }
+
+                return true;
+            });
+        }
+    }
+
+    _unbindFilterControls() {
+        var $panel = this.jq.children('.pfe-orgchart-filter-controls');
+        if (!$panel.length) {
+            return;
+        }
+
+        $panel.children('[data-pfe-role]').off(this.filterEventNamespace);
+    }
+
+    _loopVisibleHierarchies($hierarchy) {
+        if (!$hierarchy.length) {
+            return;
+        }
+
+        var $siblings = $hierarchy.children('.nodes').children('.hierarchy');
+        if ($siblings.length) {
+            $siblings.filter(':not(.hidden)').first().addClass('first-shown')
+                .end().last().addClass('last-shown');
+        }
+
+        var $this = this;
+        $siblings.each(function(index, sibling) {
+            $this._loopVisibleHierarchies($(sibling));
+        });
     }
 
     _bindEvents() {

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/orgchart.css
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/orgchart.css
@@ -266,6 +266,45 @@
   background-color: rgba(238, 217, 54, 0.5);
 }
 
+.orgchart .node.matched {
+  background-color: rgba(238, 217, 54, 0.5);
+}
+
+.pfe-orgchart-filter-controls {
+  border: 1px solid #ddd;
+  margin: 0.75rem 0;
+  padding: 0.75rem;
+  text-align: center;
+}
+
+.pfe-orgchart-filter-input {
+  margin-right: 0.5rem;
+  max-width: 320px;
+  width: 100%;
+}
+
+.pfe-orgchart-filter-button {
+  margin-right: 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.pfe-orgchart-filter-button:last-child {
+  margin-right: 0;
+}
+
+.orgchart .hierarchy.first-shown::before {
+  left: calc(50% - 1px);
+  width: calc(50% + 1px);
+}
+
+.orgchart .hierarchy.last-shown::before {
+  width: calc(50% + 1px);
+}
+
+.orgchart .hierarchy.first-shown.last-shown::before {
+  width: 2px;
+}
+
 .orgchart .ghost-node {
   position: fixed;
   left: -10000px;

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/orgchart/FilterOrgchartController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/orgchart/FilterOrgchartController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.orgchart;
+
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import org.primefaces.extensions.component.orgchart.DefaultOrgChartNode;
+import org.primefaces.extensions.component.orgchart.OrgChartNode;
+
+@Named
+@ViewScoped
+public class FilterOrgchartController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private OrgChartNode orgChartNode;
+
+    public FilterOrgchartController() {
+        init();
+    }
+
+    public void init() {
+        orgChartNode = new DefaultOrgChartNode("ceo", "CEO", "Alice Johnson");
+
+        final OrgChartNode vp1 = new DefaultOrgChartNode("vp1", "VP Sales", "Bob Martin");
+        final OrgChartNode vp2 = new DefaultOrgChartNode("vp2", "VP Engineering", "Carol White");
+
+        orgChartNode.addChild(vp1);
+        orgChartNode.addChild(vp2);
+
+        vp1.addChild(new DefaultOrgChartNode("m1", "Sales Manager", "David Green"));
+        vp1.addChild(new DefaultOrgChartNode("m2", "Account Manager", "Eve Black"));
+
+        final OrgChartNode engLead = new DefaultOrgChartNode("lead1", "Engineering Lead", "Frank Moore");
+        vp2.addChild(engLead);
+        engLead.addChild(new DefaultOrgChartNode("dev1", "Developer", "Grace Kim"));
+        engLead.addChild(new DefaultOrgChartNode("dev2", "Developer", "Henry Lee"));
+    }
+
+    public OrgChartNode getOrgChartNode() {
+        return orgChartNode;
+    }
+
+    public void setOrgChartNode(final OrgChartNode orgChartNode) {
+        this.orgChartNode = orgChartNode;
+    }
+
+}

--- a/showcase/src/main/webapp/sections/orgchart/example-filterNode.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/example-filterNode.xhtml
@@ -1,0 +1,33 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces"
+    xmlns:pe="primefaces.extensions">
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:form id="filterForm">
+        <h:panelGroup layout="block" style="margin:0 0 0.75rem 0;">
+            <h:outputText value="Programmatic API demo: quick actions can trigger common searches from business workflows." />
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" style="margin:0 0 0.75rem 0;">
+            <p:commandButton type="button" value="Quick Filter: VP"
+                onclick="PF('orgChartFilterWidget').filterNodes('VP', false); return false;" style="margin-right:0.5rem;" />
+            <p:commandButton type="button" value="Quick Filter: Developer"
+                onclick="PF('orgChartFilterWidget').filterNodes('Developer', false); return false;" style="margin-right:0.5rem;" />
+            <p:commandButton type="button" value="Clear Programmatically"
+                onclick="PF('orgChartFilterWidget').clearFilter(); return false;" />
+        </h:panelGroup>
+
+        <pe:orgchart id="orgChart"
+                    widgetVar="orgChartFilterWidget"
+                    value="#{filterOrgchartController.orgChartNode}"
+                    filterable="true"
+                    draggable="true"
+                    exportButton="true"
+                    pan="true"
+                    zoom="true"
+                    direction="t2b"
+                    style="height:420px">
+        </pe:orgchart>
+    </h:form>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/orgchart/filterNode.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/filterNode.xhtml
@@ -1,0 +1,38 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="OrgChart - Filter Node Example"/>
+        </f:facet>
+
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates client-side node filtering based on the official OrgChart filter-node behavior via a clean OrgChart widget API.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/orgchart/example-filterNode.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+${showcase:getFileContent('/sections/orgchart/example-filterNode.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/orgchart/FilterOrgchartController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/orgchart/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="orgchart"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/orgchart/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/useCasesChoice.xhtml
@@ -11,6 +11,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('colorCoded')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/orgchart/colorCoded.jsf"/>
+        <p:menuitem value="Filter Node"
+                styleClass="#{navigationContext.getMenuitemStyleClass('filterNode')}"
+                onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                url="#{request.contextPath}/sections/orgchart/filterNode.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
Resolve: #2385 

http://localhost:8080/showcase/sections/orgchart/filterNode.jsf


New attribute: `filterable`, by default, false


and once we flip it to true, filter is enable. Similar to: https://dabeng.github.io/OrgChart/filter-node.html, but the filter handling is encapsulated in the widget JS side to keep the client side clean and easy to use. 

```xhtml
<pe:orgchart id="orgChart"
                    widgetVar="orgChartFilterWidget"
                    value="#{filterOrgchartController.orgChartNode}"
                    filterable="true"
                    draggable="true"
                    exportButton="true"
                    pan="true"
                    zoom="true"
                    direction="t2b"
                    style="height:420px">
```


<img width="753" height="600" alt="image" src="https://github.com/user-attachments/assets/78606af1-a56e-4be1-82b8-d3247b3a2722" />


Quick Filter:

<img width="736" height="510" alt="image" src="https://github.com/user-attachments/assets/81d29294-0db4-4b91-8e9e-9b7f2c44db82" />

---

Built-in Textbox filter:

<img width="707" height="585" alt="image" src="https://github.com/user-attachments/assets/d5e36c0c-bd55-42b5-afd9-490b173a4f29" />


<img width="743" height="599" alt="image" src="https://github.com/user-attachments/assets/ae19fdba-c6eb-41d6-9552-158cc95ecf69" />
