### PR TITLE
#2387: Orgchart: Better documentation to demo node with different width

### DIFF
--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/orgchart/VariableWidthOrgchartController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/orgchart/VariableWidthOrgchartController.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.orgchart;
+
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import org.primefaces.extensions.component.orgchart.DefaultOrgChartNode;
+import org.primefaces.extensions.component.orgchart.OrgChartNode;
+
+/**
+ * VariableWidthOrgchartController
+ *
+ * @author @jxmai / last modified by $Author$
+ * @version $Revision$
+ */
+@Named("variableWidthOrgchartController")
+@ViewScoped
+public class VariableWidthOrgchartController implements Serializable {
+
+    private static final long serialVersionUID = 1648477595853984821L;
+
+    public OrgChartNode getOrgChartModel() {
+        DefaultOrgChartNode root = new DefaultOrgChartNode("1", "Sarah Johnson", "Chief Executive Officer & Board Member");
+        root.setClassName("wide-node");
+
+        DefaultOrgChartNode cto = new DefaultOrgChartNode("2", "Michael Chen", "Chief Technology Officer");
+        cto.setClassName("standard-node");
+
+        DefaultOrgChartNode cfo = new DefaultOrgChartNode("3", "Emily Rodriguez", "Chief Financial Officer & VP of Strategic Planning");
+        cfo.setClassName("wide-node");
+
+        DefaultOrgChartNode cmo = new DefaultOrgChartNode("4", "David Kim", "CMO");
+        cmo.setClassName("narrow-node");
+
+        DefaultOrgChartNode engManager = new DefaultOrgChartNode("5", "Robert Williams", "Engineering Manager");
+        engManager.setClassName("standard-node");
+
+        DefaultOrgChartNode finAnalyst = new DefaultOrgChartNode("6", "Lisa Brown", "Senior Analyst");
+        finAnalyst.setClassName("narrow-node");
+
+        DefaultOrgChartNode accountant = new DefaultOrgChartNode("7", "James Taylor", "Accountant");
+        accountant.setClassName("narrow-node");
+
+        root.addChild(cto);
+        root.addChild(cfo);
+        root.addChild(cmo);
+        cto.addChild(engManager);
+        cfo.addChild(finAnalyst);
+        cfo.addChild(accountant);
+
+        return root;
+    }
+
+}

--- a/showcase/src/main/webapp/sections/orgchart/example-variableWidth.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/example-variableWidth.xhtml
@@ -1,0 +1,49 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces"
+    xmlns:pe="primefaces.extensions" xmlns:f="jakarta.faces.core">
+
+    <h:form id="variableWidthForm">
+        <p:growl id="growl" showDetail="true" showSummary="true" />
+
+<!-- EXAMPLE-SOURCE-START -->
+        <style type="text/css">
+            .orgchart .wide-node .title,
+            .orgchart .wide-node .content {
+                width: 240px;
+            }
+
+            .orgchart .standard-node .title,
+            .orgchart .standard-node .content {
+                width: 160px;
+            }
+
+            .orgchart .narrow-node .title,
+            .orgchart .narrow-node .content {
+                width: 100px;
+            }
+        </style>
+
+        <pe:orgchart id="orgChart"
+                     widgetVar="variableWidthWidget"
+                     value="#{variableWidthOrgchartController.orgChartModel}"
+                     nodeId="id"
+                     nodeContent="title"
+                     nodeTitle="name"
+                     style="height:400px">
+        </pe:orgchart>
+<!-- EXAMPLE-SOURCE-END -->
+
+        <p:panel header="How it works" style="margin-top:10px">
+            <p>Nodes can have different widths to accommodate varying content lengths.
+            Use the <strong>className</strong> property on each node and define custom CSS rules
+            to set different widths for the title and content sections.</p>
+            <ul>
+                <li><strong>wide-node</strong> - 240px width for longer content</li>
+                <li><strong>standard-node</strong> - 160px width for medium content</li>
+                <li><strong>narrow-node</strong> - 100px width for short content</li>
+            </ul>
+            <p><em>Note:</em> The default node width is 130px. You can customize this by targeting
+            <code>.orgchart .your-class-name .title</code> and <code>.orgchart .your-class-name .content</code> in your CSS.</p>
+        </p:panel>
+    </h:form>
+</ui:composition>

--- a/showcase/src/main/webapp/sections/orgchart/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/useCasesChoice.xhtml
@@ -11,6 +11,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('colorCoded')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/orgchart/colorCoded.jsf"/>
+        <p:menuitem value="Variable Width Nodes"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('variableWidth')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/orgchart/variableWidth.jsf"/>
         <p:menuitem value="Filter Node"
                 styleClass="#{navigationContext.getMenuitemStyleClass('filterNode')}"
                 onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"

--- a/showcase/src/main/webapp/sections/orgchart/variableWidth.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/variableWidth.xhtml
@@ -1,0 +1,38 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="OrgChart - Variable Width Nodes"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Nodes can have different widths to accommodate varying content lengths.
+            Use the className property and custom CSS to define node widths based on content requirements.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/orgchart/example-variableWidth.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+${showcase:getFileContent('/sections/orgchart/example-variableWidth.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/orgchart/VariableWidthOrgchartController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/orgchart/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="orgchart"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>


### PR DESCRIPTION
Resolve: #2387 

http://localhost:8080/showcase/sections/orgchart/variableWidth.jsf


<img width="1028" height="679" alt="image" src="https://github.com/user-attachments/assets/bafe757c-3f29-47f7-9efd-d07fbbd7b7be" />
