### PR TITLE
#2395: Orgchart: Support Compact Mode

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/orgchart/DefaultOrgChartNode.java
+++ b/core/src/main/java/org/primefaces/extensions/component/orgchart/DefaultOrgChartNode.java
@@ -41,6 +41,8 @@ public class DefaultOrgChartNode implements OrgChartNode {
 
     private String className;
 
+    private boolean compact;
+
     private Object nodeData;
 
     private List<OrgChartNode> children = new ArrayList<>();
@@ -209,6 +211,16 @@ public class DefaultOrgChartNode implements OrgChartNode {
     @Override
     public void setClassName(final String className) {
         this.className = className;
+    }
+
+    @Override
+    public boolean isCompact() {
+        return compact;
+    }
+
+    @Override
+    public void setCompact(final boolean compact) {
+        this.compact = compact;
     }
 
     @Override

--- a/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartNode.java
+++ b/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartNode.java
@@ -64,4 +64,8 @@ public interface OrgChartNode {
 
     int getChildCount();
 
+    boolean isCompact();
+
+    void setCompact(boolean compact);
+
 }

--- a/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartRenderer.java
@@ -194,6 +194,10 @@ public class OrgChartRenderer extends CoreRenderer<OrgChart> {
             json.put("className", orgChartNode.getClassName());
         }
 
+        if (orgChartNode.isCompact()) {
+            json.put("compact", true);
+        }
+
         if (orgChartNode.getChildCount() > 0) {
             final List<JSONObject> jsonChildren = new ArrayList<>();
             for (int i = 0; i < orgChartNode.getChildCount(); i++) {

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/3-orgchart-widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/orgchart/3-orgchart-widget.js
@@ -43,16 +43,38 @@ PrimeFaces.widget.ExtOrgChart = class extends PrimeFaces.widget.BaseWidget {
         var opts = $.extend(true, {}, cfg);
         opts['data'] = JSON.parse(opts['data']);
 
-        // Map parentNodeSymbol to icons.parentNode
+        // Map parentNodeSymbol to icons, preserving all required icon classes.
+        // For Font Awesome parent symbols, keep OCI as base theme class and provide FA classes per icon.
+        // This preserves OCI compact corner toggles while rendering the rest with FA.
+        // Otherwise, OCI (built-in) icons are used as the default theme.
         if (opts.parentNodeSymbol) {
-            opts.icons = opts.icons || {};
-            opts.icons.parentNode = opts.parentNodeSymbol;
-            // Set theme based on icon prefix
-            if (opts.parentNodeSymbol.startsWith('fa-')) {
-                opts.icons.theme = 'fa';
-            } else if (opts.parentNodeSymbol.startsWith('oci-')) {
-                opts.icons.theme = 'oci';
-            }
+            var isFa = opts.parentNodeSymbol.startsWith('fa-');
+            var defaults = isFa ? {
+                'theme': 'oci',
+                'parentNode': 'fa ' + opts.parentNodeSymbol,
+                'expandToUp': 'fa fa-chevron-up',
+                'collapseToDown': 'fa fa-chevron-down',
+                'collapseToLeft': 'fa fa-chevron-left',
+                'expandToRight': 'fa fa-chevron-right',
+                'backToCompact': 'oci-corner-top-left',
+                'backToLoose': 'oci-corner-bottom-right',
+                'collapsed': 'fa fa-plus-square',
+                'expanded': 'fa fa-minus-square',
+                'spinner': 'fa fa-spinner'
+            } : {
+                'theme': 'oci',
+                'parentNode': opts.parentNodeSymbol,
+                'expandToUp': 'oci-chevron-up',
+                'collapseToDown': 'oci-chevron-down',
+                'collapseToLeft': 'oci-chevron-left',
+                'expandToRight': 'oci-chevron-right',
+                'backToCompact': 'oci-corner-top-left',
+                'backToLoose': 'oci-corner-bottom-right',
+                'collapsed': 'oci-plus-square',
+                'expanded': 'oci-minus-square',
+                'spinner': 'oci-spinner'
+            };
+            opts.icons = $.extend({}, defaults, opts.icons);
         }
 
         this.orgchart = this.jq.orgchart(opts);

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/orgchart/CompactOrgchartController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/orgchart/CompactOrgchartController.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.orgchart;
+
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import org.primefaces.extensions.component.orgchart.DefaultOrgChartNode;
+import org.primefaces.extensions.component.orgchart.OrgChartNode;
+
+/**
+ * CompactOrgchartController
+ *
+ * @author @jxmai / last modified by $Author$
+ * @version $Revision$
+ */
+@Named("compactOrgchartController")
+@ViewScoped
+public class CompactOrgchartController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private OrgChartNode orgChartNode;
+
+    public CompactOrgchartController() {
+        init();
+    }
+
+    public void init() {
+        orgChartNode = new DefaultOrgChartNode("root", "Lao Lao", "General Manager");
+
+        final DefaultOrgChartNode boMiao = new DefaultOrgChartNode("n1", "Bo Miao", "Department Manager");
+        boMiao.setCompact(true);
+        boMiao.addChild(new DefaultOrgChartNode("n1a", "Fei Xuan", "Engineer"));
+        boMiao.addChild(new DefaultOrgChartNode("n1b", "Er Xuan", "Engineer"));
+        boMiao.addChild(new DefaultOrgChartNode("n1c", "San Xuan", "Engineer"));
+
+        final DefaultOrgChartNode siXuan = new DefaultOrgChartNode("n1d", "Si Xuan", "Engineer");
+        siXuan.setCompact(true);
+        siXuan.addChild(new DefaultOrgChartNode("n1d1", "Feng Shou", "Engineer"));
+        siXuan.addChild(new DefaultOrgChartNode("n1d2", "Er Shou", "Engineer"));
+        siXuan.addChild(new DefaultOrgChartNode("n1d3", "San Shou", "Engineer"));
+        siXuan.addChild(new DefaultOrgChartNode("n1d4", "Si Shou", "Engineer"));
+        boMiao.addChild(siXuan);
+
+        boMiao.addChild(new DefaultOrgChartNode("n1e", "Wu Xuan", "Engineer"));
+
+        final DefaultOrgChartNode suMiao = new DefaultOrgChartNode("n2", "Su Miao", "Department Manager");
+        suMiao.addChild(new DefaultOrgChartNode("n2a", "Tie Hua", "Senior Engineer"));
+        final DefaultOrgChartNode heiHei = new DefaultOrgChartNode("n2b", "Hei Hei", "Senior Engineer");
+        heiHei.addChild(new DefaultOrgChartNode("n2b1", "Dan Dan", "Engineer"));
+        heiHei.addChild(new DefaultOrgChartNode("n2b2", "Er Dan", "Engineer"));
+        heiHei.addChild(new DefaultOrgChartNode("n2b3", "San Dan", "Engineer"));
+        suMiao.addChild(heiHei);
+        suMiao.addChild(new DefaultOrgChartNode("n2c", "Pang Pang", "Senior Engineer"));
+
+        final DefaultOrgChartNode hongMiao = new DefaultOrgChartNode("n3", "Hong Miao", "Department Manager");
+
+        orgChartNode.addChild(boMiao);
+        orgChartNode.addChild(suMiao);
+        orgChartNode.addChild(hongMiao);
+    }
+
+    public OrgChartNode getOrgChartNode() {
+        return orgChartNode;
+    }
+
+    public void setOrgChartNode(final OrgChartNode orgChartNode) {
+        this.orgChartNode = orgChartNode;
+    }
+
+}

--- a/showcase/src/main/webapp/sections/orgchart/compactMode.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/compactMode.xhtml
@@ -1,0 +1,41 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="OrgChart - Compact Mode"/>
+        </f:facet>
+
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates the <em>compact</em> data property. Nodes marked with
+            <code>compact=true</code> render children in a grid inside the parent node,
+            which helps when many children exist. Use the green corner controls to switch
+            between compact and loose views.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/orgchart/example-compactMode.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+${showcase:getFileContent('/sections/orgchart/example-compactMode.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/orgchart/CompactOrgchartController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/orgchart/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="orgchart"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/orgchart/compactMode.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/compactMode.xhtml
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
       xmlns:showcase="primefaces.extensions.showcase">
 <ui:composition template="/templates/showcaseLayout.xhtml">
     <ui:define name="centerContent">

--- a/showcase/src/main/webapp/sections/orgchart/example-compactMode.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/example-compactMode.xhtml
@@ -1,0 +1,40 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces"
+    xmlns:pe="primefaces.extensions">
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <style type="text/css">
+        .compact-demo .orgchart {
+            background: unset;
+        }
+    </style>
+
+    <h:form id="compactForm">
+
+        <h:panelGroup layout="block" styleClass="compact-demo" style="margin:0 0 0.75rem 0;">
+            <pe:orgchart id="orgChart"
+                        widgetVar="orgChartCompact"
+                        value="#{compactOrgchartController.orgChartNode}"
+                        nodeContent="title"
+                        parentNodeSymbol="fa-users"
+                        pan="true"
+                        zoom="true"
+                        direction="t2b"
+                        style="height:480px">
+            </pe:orgchart>
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" style="margin:0.75rem 0 0 0;">
+            <p:panel header="About Compact Mode">
+                Set <code>compact=true</code> on a node to display its children in a compact grid
+                inside the parent box.
+                <br/><br/>
+                In this sample, <strong>Bo Miao</strong> is compact and includes a nested compact node
+                (<strong>Si Xuan</strong>). Use the green corner controls to switch between compact and
+                loose layouts.
+            </p:panel>
+        </h:panelGroup>
+
+    </h:form>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/orgchart/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/orgchart/useCasesChoice.xhtml
@@ -19,6 +19,10 @@
                 styleClass="#{navigationContext.getMenuitemStyleClass('filterNode')}"
                 onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                 url="#{request.contextPath}/sections/orgchart/filterNode.jsf"/>
+        <p:menuitem value="Compact Mode"
+                styleClass="#{navigationContext.getMenuitemStyleClass('compactMode')}"
+                onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                url="#{request.contextPath}/sections/orgchart/compactMode.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
Resolve: #2395

http://localhost:8080/showcase/sections/orgchart/compactMode.jsf

<img width="568" height="366" alt="image" src="https://github.com/user-attachments/assets/6feab806-5296-455c-bf94-eadc6c189036" />



Note: 


```js
var isFa = opts.parentNodeSymbol.startsWith('fa-');
            var defaults = isFa ? {
                'theme': 'oci',
                'parentNode': 'fa ' + opts.parentNodeSymbol,
                'expandToUp': 'fa fa-chevron-up',
                'collapseToDown': 'fa fa-chevron-down',
                'collapseToLeft': 'fa fa-chevron-left',
                'expandToRight': 'fa fa-chevron-right',
                'backToCompact': 'oci-corner-top-left',
                'backToLoose': 'oci-corner-bottom-right',
                'collapsed': 'fa fa-plus-square',
                'expanded': 'fa fa-minus-square',
                'spinner': 'fa fa-spinner'
            } : {
                'theme': 'oci',
                'parentNode': opts.parentNodeSymbol,
                'expandToUp': 'oci-chevron-up',
                'collapseToDown': 'oci-chevron-down',
                'collapseToLeft': 'oci-chevron-left',
                'expandToRight': 'oci-chevron-right',
                'backToCompact': 'oci-corner-top-left',
                'backToLoose': 'oci-corner-bottom-right',
                'collapsed': 'oci-plus-square',
                'expanded': 'oci-minus-square',
                'spinner': 'oci-spinner'
            };
            opts.icons = $.extend({}, defaults, opts.icons);
```

This part is done on purpose since I noticed some bug if we activate fa that could lose the original styling for orgchart.

theme: 'oci' keeps OrgChart’s OCI corner behavior/CSS.

backToCompact / backToLoose stay OCI (oci-corner-*) to preserve the original green compact-mode triangles.

In summary, his block is basically a compatibility workaround:
single chart uses mostly FA icons, but compact toggles remain OCI style.


