### PR TITLE
#2402: drop UIData inheritance from OrgChart (use UIOutput)

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/orgchart/OrgChartBase.java
@@ -21,7 +21,7 @@
  */
 package org.primefaces.extensions.component.orgchart;
 
-import jakarta.faces.component.UIData;
+import jakarta.faces.component.UIOutput;
 
 import org.primefaces.cdk.api.FacesBehaviorEvent;
 import org.primefaces.cdk.api.FacesBehaviorEvents;
@@ -44,7 +44,7 @@ import org.primefaces.extensions.event.OrgChartDropEvent;
                         defaultEvent = true),
             @FacesBehaviorEvent(name = "drop", event = OrgChartDropEvent.class, description = "Fires when a node is dropped after dragging.")
 })
-public abstract class OrgChartBase extends UIData implements Widget, StyleAware {
+public abstract class OrgChartBase extends UIOutput implements Widget, StyleAware {
 
     public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.OrgChart";
     public static final String COMPONENT_FAMILY = "org.primefaces.extensions.component";


### PR DESCRIPTION
Resolve: #2402 

http://localhost:8080/showcase/sections/orgchart/basicUsage.jsf

Those unused attributes are gone:

<img width="427" height="589" alt="image" src="https://github.com/user-attachments/assets/9a3acd6e-e61d-402b-8d2d-bfc2fdaa61b0" />
