### PR TITLE
PF 15 Backport #2380: Search (MarkText): Support Exclude Selector

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
@@ -21,6 +21,8 @@
  */
 package org.primefaces.extensions.component.marktext;
 
+import java.util.List;
+
 import javax.faces.component.UIComponentBase;
 import javax.faces.component.behavior.ClientBehaviorHolder;
 
@@ -52,7 +54,8 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, Cl
         accuracy,
         synonyms,
         acrossElements,
-        wildcards
+        wildcards,
+        exclude;
         //@formatter:on
     }
 
@@ -151,5 +154,14 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, Cl
 
     public void setAcrossElements(final Boolean acrossElements) {
         getStateHelper().put(PropertyKeys.acrossElements, acrossElements);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<String> getExclude() {
+        return (List<String>) getStateHelper().eval(PropertyKeys.exclude, null);
+    }
+
+    public void setExclude(List<String> exclude) {
+        getStateHelper().put(PropertyKeys.exclude, exclude);
     }
 }

--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
@@ -161,7 +161,7 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, Cl
         return (List<String>) getStateHelper().eval(PropertyKeys.exclude, null);
     }
 
-    public void setExclude(List<String> exclude) {
+    public void setExclude(final List<String> exclude) {
         getStateHelper().put(PropertyKeys.exclude, exclude);
     }
 }

--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
@@ -76,8 +76,13 @@ public class MarkTextRenderer extends CoreRenderer {
         wb.attr("acrossElements", markText.getAcrossElements());
         wb.attr("wildcards", markText.getWildcards());
         wb.attr("className", markText.getStyleClass());
+
         if (markText.getSynonyms() != null) {
             wb.nativeAttr("synonyms", new Gson().toJson(markText.getSynonyms()));
+        }
+
+        if (markText.getExclude() != null) {
+            wb.nativeAttr("exclude", new Gson().toJson(markText.getExclude()));
         }
 
         encodeClientBehaviors(context, markText);

--- a/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -3220,6 +3220,14 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Array of exclusion selectors. Matches inside these elements will be ignored.]]>
+            </description>
+            <name>exclude</name>
+            <required>false</required>
+            <type>java.util.List</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
@@ -18,7 +18,9 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
         this.caseSensitive = cfg.caseSensitive;
         this.separateWordSearch = cfg.separateWordSearch;
         this.accuracy = cfg.accuracy;
+
         this.synonyms = cfg.synonyms ? (typeof cfg.synonyms === 'string' ? JSON.parse(cfg.synonyms) : cfg.synonyms) : {};
+        this.exclude = cfg.exclude ? (typeof cfg.exclude === 'string' ? JSON.parse(cfg.exclude) : cfg.exclude) : [];
         this.acrossElements = cfg.acrossElements !== undefined ? cfg.acrossElements : false;
         this.wildcards = cfg.wildcards || 'disabled';
 
@@ -75,6 +77,7 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
                     wildcards: this.wildcards,
                     className: this.cfg.className,
                     synonyms: this.synonyms,
+                    exclude: this.exclude,
                     acrossElements: this.acrossElements,
                     each: function(element) {
                         var term = $(element).text();

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/MarkTextExcludeController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/MarkTextExcludeController.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2025 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.marktext;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+/**
+ * MarkText exclude controller.
+ *
+ * @author jxmai
+ */
+@Named
+@ViewScoped
+public class MarkTextExcludeController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String searchTerm = "PrimeFaces";
+
+    private final List<String> availableExcludes = Arrays.asList("h3", ".ignore", ".notes");
+
+    private List<String> excludedSelectors = new ArrayList<>(Arrays.asList("h3", ".ignore"));
+
+    public String getSearchTerm() {
+        return searchTerm;
+    }
+
+    public void setSearchTerm(String searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    public List<String> getAvailableExcludes() {
+        return availableExcludes;
+    }
+
+    public List<String> getExcludedSelectors() {
+        return excludedSelectors;
+    }
+
+    public void setExcludedSelectors(List<String> excludedSelectors) {
+        this.excludedSelectors = excludedSelectors;
+    }
+}

--- a/showcase/src/main/webapp/sections/marktext/example-exclude.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-exclude.xhtml
@@ -1,0 +1,71 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:f="http://xmlns.jcp.org/jsf/core"
+        xmlns:p="http://primefaces.org/ui"
+        xmlns:pe="http://primefaces.org/ui/extensions">
+
+    <p:messages id="messages" showSummary="true" showDetail="true">
+        <p:autoUpdate/>
+    </p:messages>
+
+    <style>
+        .marktext-highlight {
+            background-color: yellow !important;
+            color: black !important;
+        }
+        .ignore,
+        .notes {
+            display: block;
+            padding: 0.5rem;
+            border-left: 4px solid #b0bec5;
+            background: #eceff1;
+            margin: 0.5rem 0;
+        }
+        mark {
+            background-color: yellow !important;
+            color: black !important;
+        }
+    </style>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="2" columnClasses="label,value" styleClass="ui-fluid">
+        <h:outputText value="Search term:"/>
+        <p:inputText id="searchInput" value="#{markTextExcludeController.searchTerm}" placeholder="Enter search term">
+            <p:ajax event="keyup" delay="300" update="markText activeExcludes" process="@this"/>
+        </p:inputText>
+
+        <h:outputText value="Excluded selectors:"/>
+        <p:selectManyCheckbox id="excludeSelectors" value="#{markTextExcludeController.excludedSelectors}" layout="pageDirection">
+            <f:selectItems value="#{markTextExcludeController.availableExcludes}" var="selector" itemLabel="#{selector}" itemValue="#{selector}"/>
+            <p:ajax event="change" update="markText activeExcludes" process="@this"/>
+        </p:selectManyCheckbox>
+    </h:panelGrid>
+
+    <p:panel id="activeExcludes" header="Current Exclusion Rules" style="margin-top: 1rem">
+        <h:outputText value="#{empty markTextExcludeController.excludedSelectors ? 'No selectors excluded. All matching text can be highlighted.' : markTextExcludeController.excludedSelectors}"/>
+    </p:panel>
+
+    <p:panel id="searchContainer" header="Searchable Content" style="margin-top: 1rem">
+        <h:panelGroup id="searchContent" layout="block">
+            <h3>PrimeFaces heading stays unmarked when h3 is excluded</h3>
+            <p>
+                PrimeFaces Extensions enhances PrimeFaces with additional components. This PrimeFaces occurrence in a normal paragraph should be highlighted.
+            </p>
+            <span class="ignore">
+                PrimeFaces inside this .ignore block should remain untouched when .ignore is excluded.
+            </span>
+            <p>
+                You can toggle exclusions to compare normal matches against ignored regions and verify that PrimeFaces is only marked in eligible content.
+            </p>
+            <div class="notes">
+                PrimeFaces inside this .notes block becomes ignored only when .notes is selected.
+            </div>
+        </h:panelGroup>
+    </p:panel>
+
+    <pe:markText id="markText" for="searchContent" value="#{markTextExcludeController.searchTerm}"
+                 exclude="#{markTextExcludeController.excludedSelectors}" styleClass="marktext-highlight" caseSensitive="false"/>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/exclude.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/exclude.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:showcase="http://primefaces.org/ui/extensions/showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MarkText - Exclude Selectors"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates the exclude attribute, which skips highlighting inside selected elements such as headings or regions marked with CSS classes.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/marktext/example-exclude.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+                ${showcase:getFileContent('/sections/marktext/example-exclude.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/MarkTextExcludeController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/marktext/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="markText"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
@@ -35,10 +35,14 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('advancedFeatures')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/marktext/advancedFeatures.jsf"/>
+        <p:menuitem value="Exclude Selectors"
+            styleClass="#{navigationContext.getMenuitemStyleClass('exclude')}"
+            onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+            url="#{request.contextPath}/sections/marktext/exclude.jsf"/>
         <p:menuitem value="Wildcard Search"
-                styleClass="#{navigationContext.getMenuitemStyleClass('wildcardSearch')}"
-                onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
-                url="#{request.contextPath}/sections/marktext/wildcard.jsf"/>
+            styleClass="#{navigationContext.getMenuitemStyleClass('wildcardSearch')}"
+            onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+            url="#{request.contextPath}/sections/marktext/wildcard.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
Backport: #2380 

http://localhost:8080/showcase-ext/sections/marktext/exclude.jsf

<img width="1069" height="673" alt="image" src="https://github.com/user-attachments/assets/eb7f3034-3e31-4c3e-b051-165d655c097e" />
