### PR TITLE
#2417: Optimize MarkTextRenderer: instantiate Gson only if needed

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
@@ -77,11 +77,19 @@ public class MarkTextRenderer extends CoreRenderer<MarkText> {
         wb.attr("acrossElements", component.getAcrossElements());
         wb.attr("wildcards", component.getWildcards());
         wb.attr("className", component.getStyleClass());
+
+        Gson gson = null;
         if (component.getSynonyms() != null) {
-            wb.nativeAttr("synonyms", new Gson().toJson(component.getSynonyms()));
+            if (gson == null) {
+                gson = new Gson();
+            }
+            wb.nativeAttr("synonyms", gson.toJson(component.getSynonyms()));
         }
         if (component.getExclude() != null) {
-            wb.nativeAttr("exclude", new Gson().toJson(component.getExclude()));
+            if (gson == null) {
+                gson = new Gson();
+            }
+            wb.nativeAttr("exclude", gson.toJson(component.getExclude()));
         }
 
         encodeClientBehaviors(context, component);


### PR DESCRIPTION
Resolve: #2417 