### PR TITLE
PF 15 Backport #2439: Search (MarkText): Support diacritics

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
@@ -53,6 +53,7 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, Cl
         separateWordSearch,
         accuracy,
         synonyms,
+        diacritics,
         acrossElements,
         wildcards,
         exclude;
@@ -138,6 +139,14 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, Cl
 
     public void setWildcards(final String wildcards) {
         getStateHelper().put(PropertyKeys.wildcards, wildcards);
+    }
+
+    public Boolean getDiacritics() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.diacritics, Boolean.TRUE);
+    }
+
+    public void setDiacritics(final Boolean diacritics) {
+        getStateHelper().put(PropertyKeys.diacritics, diacritics);
     }
 
     public Object getSynonyms() {

--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
@@ -73,6 +73,7 @@ public class MarkTextRenderer extends CoreRenderer {
         wb.attr("caseSensitive", markText.getCaseSensitive());
         wb.attr("separateWordSearch", markText.getSeparateWordSearch());
         wb.attr("accuracy", markText.getAccuracy());
+        wb.attr("diacritics", markText.getDiacritics());
         wb.attr("acrossElements", markText.getAcrossElements());
         wb.attr("wildcards", markText.getWildcards());
         wb.attr("className", markText.getStyleClass());

--- a/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
+++ b/core/src/main/resources/META-INF/primefaces-extensions.taglib.xml
@@ -3198,6 +3198,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Whether accented and unaccented letters are treated as the same during matching. Default is true.]]>
+            </description>
+            <name>diacritics</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Wildcard matching mode: 'disabled'|'enabled'|'withSpaces'. Default is 'disabled'.]]>
             </description>
             <name>wildcards</name>

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
@@ -18,6 +18,7 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
         this.caseSensitive = cfg.caseSensitive;
         this.separateWordSearch = cfg.separateWordSearch;
         this.accuracy = cfg.accuracy;
+        this.diacritics = cfg.diacritics !== undefined ? cfg.diacritics : true;
 
         this.synonyms = cfg.synonyms ? (typeof cfg.synonyms === 'string' ? JSON.parse(cfg.synonyms) : cfg.synonyms) : {};
         this.exclude = cfg.exclude ? (typeof cfg.exclude === 'string' ? JSON.parse(cfg.exclude) : cfg.exclude) : [];
@@ -74,6 +75,7 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
                     caseSensitive: this.caseSensitive,
                     separateWordSearch: this.separateWordSearch,
                     accuracy: this.accuracy,
+                    diacritics: this.diacritics,
                     wildcards: this.wildcards,
                     className: this.cfg.className,
                     synonyms: this.synonyms,

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/DiacriticsMarkTextController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/DiacriticsMarkTextController.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2011-2025 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.marktext;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+import org.primefaces.extensions.event.MarkEvent;
+import org.primefaces.extensions.model.marktext.MarkPosition;
+
+/**
+ * Diacritics behavior example for MarkText.
+ *
+ * @author jxmai
+ */
+@Named
+@ViewScoped
+public class DiacriticsMarkTextController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String searchTerm = "cafe";
+
+    private Boolean diacritics = Boolean.TRUE;
+
+    private String processedText = "Café, caFe, cafe, façade, naive, naïve, résumé, resume.";
+
+    private List<String> lastMatchedTerms = new ArrayList<>();
+
+    private List<MarkPosition> lastPositions = new ArrayList<>();
+
+    public String getSearchTerm() {
+        return searchTerm;
+    }
+
+    public void setSearchTerm(String searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    public Boolean getDiacritics() {
+        return diacritics;
+    }
+
+    public void setDiacritics(Boolean diacritics) {
+        this.diacritics = diacritics;
+    }
+
+    public String getProcessedText() {
+        return processedText;
+    }
+
+    public void setProcessedText(String processedText) {
+        this.processedText = processedText;
+    }
+
+    public List<String> getLastMatchedTerms() {
+        return lastMatchedTerms;
+    }
+
+    public List<MarkPosition> getLastPositions() {
+        return lastPositions;
+    }
+
+    public void onHighlight(MarkEvent event) {
+        this.lastMatchedTerms = event.getMatchedTerms();
+        this.lastPositions = event.getPositions();
+
+        FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Mark Event Triggered",
+                                "Found " + lastMatchedTerms.size() + " matched terms and " + lastPositions.size() + " positions."));
+    }
+}

--- a/showcase/src/main/webapp/sections/marktext/diacritics.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/diacritics.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:showcase="http://primefaces.org/ui/extensions/showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MarkText - Diacritics"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates mark.js diacritics handling.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/marktext/example-diacritics.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+                ${showcase:getFileContent('/sections/marktext/example-diacritics.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/DiacriticsMarkTextController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/marktext/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="markText"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/example-diacritics.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-diacritics.xhtml
@@ -1,0 +1,51 @@
+<ui:composition
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:p="http://primefaces.org/ui"
+    xmlns:pe="http://primefaces.org/ui/extensions">
+
+    <p:messages id="messages" showSummary="true" showDetail="true">
+        <p:autoUpdate/>
+    </p:messages>
+
+    <style>
+        .marktext-highlight {
+            background-color: yellow !important;
+            color: black !important;
+        }
+        mark {
+            background-color: yellow !important;
+            color: black !important;
+        }
+    </style>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="3">
+        <h:outputText value="Search term:"/>
+        <p:inputText id="searchInput" value="#{diacriticsMarkTextController.searchTerm}" placeholder="Enter search term">
+            <p:ajax event="keyup" delay="500" update="searchContainer markText"/>
+        </p:inputText>
+        <p:commandButton value="Highlight" update="searchContainer markText" icon="pi pi-search"/>
+    </h:panelGrid>
+
+    <h:panelGrid columns="2" style="margin-top:10px">
+        <h:outputText value="Consider diacritics:"/>
+        <p:selectBooleanCheckbox value="#{diacriticsMarkTextController.diacritics}">
+            <p:ajax update="markText searchContainer" process="@this"/>
+        </p:selectBooleanCheckbox>
+    </h:panelGrid>
+
+    <p:panel id="searchContainer" header="Searchable Content" style="margin-top: 20px">
+        <h:panelGroup id="searchContent" layout="block">
+            <p>#{diacriticsMarkTextController.processedText}</p>
+        </h:panelGroup>
+    </p:panel>
+
+    <pe:markText id="markText" widgetVar="markTextWidget" for="searchContent" value="#{diacriticsMarkTextController.searchTerm}"
+                 diacritics="#{diacriticsMarkTextController.diacritics}" styleClass="marktext-highlight">
+        <p:ajax event="mark" listener="#{diacriticsMarkTextController.onHighlight}"/>
+    </pe:markText>
+    <!-- EXAMPLE-SOURCE-END -->
+
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
@@ -27,7 +27,7 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('synonyms')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/marktext/synonyms.jsf"/>
-            <p:menuitem value="Diacritics"
+        <p:menuitem value="Diacritics"
                     styleClass="#{navigationContext.getMenuitemStyleClass('diacritics')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/marktext/diacritics.jsf"/>

--- a/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
@@ -27,6 +27,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('synonyms')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/marktext/synonyms.jsf"/>
+            <p:menuitem value="Diacritics"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('diacritics')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/marktext/diacritics.jsf"/>
         <p:menuitem value="Across Elements"
                     styleClass="#{navigationContext.getMenuitemStyleClass('acrossElements')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"


### PR DESCRIPTION
Backport: #2439 

http://localhost:8080/showcase-ext/sections/marktext/diacritics.jsf

<img width="495" height="317" alt="image" src="https://github.com/user-attachments/assets/af928d6a-e254-459d-a161-fb3212aaf4da" />


---

<img width="465" height="329" alt="image" src="https://github.com/user-attachments/assets/0ee4e32d-b985-4ca1-aa82-d9908f252e2b" />
