### PR TITLE
#2447: Search (MarkText): Support iframe search with iframeTimeout

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
@@ -82,6 +82,12 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, St
     @Property(description = "Array of exclusion selectors. Matches inside these elements will be ignored.")
     public abstract List<String> getExclude();
 
+    @Property(description = "Whether matching should include same-origin iframe documents.", defaultValue = "false")
+    public abstract Boolean getIframes();
+
+    @Property(description = "Maximum wait time in milliseconds for iframe loading.", defaultValue = "5000")
+    public abstract Integer getIframesTimeout();
+
     @Property(description = "Search across element boundaries.", defaultValue = "false")
     public abstract Boolean getAcrossElements();
 

--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
@@ -75,6 +75,8 @@ public class MarkTextRenderer extends CoreRenderer<MarkText> {
         wb.attr("separateWordSearch", component.getSeparateWordSearch());
         wb.attr("accuracy", component.getAccuracy());
         wb.attr("diacritics", component.getDiacritics());
+        wb.attr("iframes", component.getIframes());
+        wb.attr("iframesTimeout", component.getIframesTimeout());
         wb.attr("acrossElements", component.getAcrossElements());
         wb.attr("wildcards", component.getWildcards());
         wb.attr("className", component.getStyleClass());

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
@@ -20,6 +20,8 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
         this.separateWordSearch = cfg.separateWordSearch;
         this.accuracy = cfg.accuracy;
         this.diacritics = cfg.diacritics !== undefined ? cfg.diacritics : true;
+        this.iframes = cfg.iframes !== undefined ? cfg.iframes : false;
+        this.iframesTimeout = cfg.iframesTimeout !== undefined && cfg.iframesTimeout !== null ? cfg.iframesTimeout : 5000;
         this.synonyms = cfg.synonyms ? (typeof cfg.synonyms === 'string' ? JSON.parse(cfg.synonyms) : cfg.synonyms) : {};
         this.exclude = cfg.exclude || [];
         this.acrossElements = cfg.acrossElements !== undefined ? cfg.acrossElements : false;
@@ -75,6 +77,8 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
                     separateWordSearch: this.separateWordSearch,
                     accuracy: this.accuracy,
                     diacritics: this.diacritics,
+                    iframes: this.iframes,
+                    iframesTimeout: this.iframesTimeout,
                     className: this.cfg.className,
                     synonyms: this.synonyms,
                     exclude: this.exclude,
@@ -86,10 +90,13 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
                             matchedTerms.push(term);
                         }
 
-                        var range = document.createRange();
-                        range.selectNodeContents(targetElement[0]);
-                        range.setEndBefore(element);
-                        var start = range.toString().length;
+                        var start = 0;
+                        if (element.ownerDocument === targetElement[0].ownerDocument) {
+                            var range = element.ownerDocument.createRange();
+                            range.selectNodeContents(targetElement[0]);
+                            range.setEndBefore(element);
+                            start = range.toString().length;
+                        }
 
                         var $mark = $(element);
                         var nearestParentWithId = $mark.closest('[id]');

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package-lock.json
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/monacoeditor/package-lock.json
@@ -219,6 +219,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -376,6 +377,7 @@
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.9.tgz",
       "integrity": "sha512-COQsxlVrmcRIbZMMTYwD+C2bxYCFDNQ2EHESklPiInbD/Pk3JZ6qNL84Bp9wWjYjAzXfSlsNaFtRk+hO9yBPWA==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/visjs"
@@ -409,6 +411,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.7.tgz",
       "integrity": "sha512-E3L03G3+trvc/X4LXvBfih3YIHcKS2WrP0XTdZefr6W6Qi/2nNCqZfe4JFfJU6DcQLm6Gxqj2Pfl+02859oL5A==",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -425,6 +428,7 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
       "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "peer": true,
       "dependencies": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"
@@ -629,7 +633,8 @@
     "moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true
     },
     "moment-timezone": {
       "version": "0.5.45",
@@ -739,6 +744,7 @@
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.9.tgz",
       "integrity": "sha512-COQsxlVrmcRIbZMMTYwD+C2bxYCFDNQ2EHESklPiInbD/Pk3JZ6qNL84Bp9wWjYjAzXfSlsNaFtRk+hO9yBPWA==",
+      "peer": true,
       "requires": {}
     },
     "vis-timeline": {
@@ -751,12 +757,14 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.7.tgz",
       "integrity": "sha512-E3L03G3+trvc/X4LXvBfih3YIHcKS2WrP0XTdZefr6W6Qi/2nNCqZfe4JFfJU6DcQLm6Gxqj2Pfl+02859oL5A==",
+      "peer": true,
       "requires": {}
     },
     "xss": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
       "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "peer": true,
       "requires": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"

--- a/core/src/test/java/org/primefaces/extensions/component/marktext/MarkTextTest.java
+++ b/core/src/test/java/org/primefaces/extensions/component/marktext/MarkTextTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.component.marktext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * MarkText component tests.
+ */
+public class MarkTextTest {
+
+    @Test
+    void iframeDefaults() {
+        MarkText markText = new MarkText();
+
+        assertFalse(markText.getIframes());
+        assertEquals(5000, markText.getIframesTimeout().intValue());
+    }
+
+    @Test
+    void iframePropertiesCanBeUpdated() {
+        MarkText markText = new MarkText();
+
+        markText.setIframes(true);
+        markText.setIframesTimeout(2500);
+
+        assertTrue(markText.getIframes());
+        assertEquals(2500, markText.getIframesTimeout().intValue());
+    }
+}

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/IframeMarkTextController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/IframeMarkTextController.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.marktext;
+
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+/**
+ * Iframe MarkText Controller.
+ *
+ * @author jxmai
+ */
+@Named
+@ViewScoped
+public class IframeMarkTextController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String searchTerm = "compliance";
+
+    private boolean iframes = true;
+
+    private int iframesTimeout = 5000;
+
+    public String getSearchTerm() {
+        return searchTerm;
+    }
+
+    public void setSearchTerm(String searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    public boolean isIframes() {
+        return iframes;
+    }
+
+    public void setIframes(boolean iframes) {
+        this.iframes = iframes;
+    }
+
+    public int getIframesTimeout() {
+        return iframesTimeout;
+    }
+
+    public void setIframesTimeout(int iframesTimeout) {
+        this.iframesTimeout = iframesTimeout;
+    }
+}

--- a/showcase/src/main/webapp/sections/marktext/example-iframeSupport.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-iframeSupport.xhtml
@@ -1,0 +1,73 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+
+    <style>
+        .marktext-highlight {
+            background-color: #ffeb3b !important;
+            color: #111827 !important;
+        }
+        mark {
+            background-color: #ffeb3b !important;
+            color: #111827 !important;
+        }
+    </style>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="7" cellpadding="6" style="margin-bottom: 12px;">
+        <h:outputText value="Search term:"/>
+        <p:inputText id="searchTerm" value="#{iframeMarkTextController.searchTerm}" placeholder="e.g. compliance">
+            <p:ajax event="keyup" delay="500" update="searchArea markTextIframe"/>
+        </p:inputText>
+
+        <h:outputText value="Search iframes:"/>
+        <p:selectBooleanCheckbox value="#{iframeMarkTextController.iframes}">
+            <p:ajax update="searchArea markTextIframe"/>
+        </p:selectBooleanCheckbox>
+
+        <h:outputText value="Timeout (ms):"/>
+        <p:inputNumber id="iframeTimeout" value="#{iframeMarkTextController.iframesTimeout}" minValue="0" decimalPlaces="0">
+            <p:ajax event="blur" update="searchArea markTextIframe"/>
+        </p:inputNumber>
+
+        <p:commandButton value="Highlight" icon="pi pi-search" update="searchArea markTextIframe"/>
+    </h:panelGrid>
+
+    <p:panel id="searchArea" header="Operational Guide with Embedded Policy Frame">
+        <p:messages id="iframeInfo" closable="true">
+            <p:autoUpdate/>
+        </p:messages>
+
+        <p style="margin-top: 0;">
+            This example searches both the parent document and a same-origin iframe.
+            Enable <code>iframes</code> to include embedded frame content in the highlight result.
+        </p>
+
+        <h:panelGroup id="searchContent" layout="block">
+            <h3>Parent Document Content</h3>
+            <p>
+                The compliance team reviews policy updates every sprint and tracks mandatory training tasks.
+                A professional rollout plan should include communication, compliance checkpoints, and audit readiness.
+            </p>
+            <p>
+                Use the controls above to test search behavior when iframe scanning is enabled or disabled.
+            </p>
+
+            <h3 style="margin-top: 18px;">Embedded Policy Frame (Same Origin)</h3>
+            <iframe title="Policy Frame"
+                    src="#{request.contextPath}/sections/marktext/iframe-policy-content.html"
+                    style="width: 100%; height: 210px; border: 1px solid var(--surface-border, #d1d5db); border-radius: 4px;"></iframe>
+        </h:panelGroup>
+    </p:panel>
+
+    <pe:markText id="markTextIframe"
+                 for="searchContent"
+                 value="#{iframeMarkTextController.searchTerm}"
+                 styleClass="marktext-highlight"
+                 iframes="#{iframeMarkTextController.iframes}"
+                 iframesTimeout="#{iframeMarkTextController.iframesTimeout}"/>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/iframe-policy-content.html
+++ b/showcase/src/main/webapp/sections/marktext/iframe-policy-content.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Policy Notes</title>
+    <style>
+        body {
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            color: #111827;
+            margin: 0;
+            padding: 12px 16px;
+            line-height: 1.5;
+            background: #f9fafb;
+        }
+        h3 {
+            font-weight: 700;
+            font-size: 1rem;
+            margin: 0 0 8px;
+            color: #0f172a;
+        }
+        p {
+            margin: 0 0 8px;
+        }
+        .note {
+            margin: 8px 0 0;
+            color: #374151;
+            font-size: 0.9rem;
+            border-top: 1px solid #e5e7eb;
+            padding-top: 8px;
+        }
+        code {
+            background: #f1f5f9;
+            padding: 1px 4px;
+            border-radius: 3px;
+            font-size: 0.85em;
+        }
+        mark {
+            background-color: #ffeb3b;
+            color: #111827;
+            border-radius: 2px;
+            padding: 0 1px;
+        }
+        .marktext-highlight {
+            background-color: #ffeb3b !important;
+            color: #111827 !important;
+            border-radius: 2px;
+            padding: 0 1px;
+        }
+    </style>
+</head>
+<body>
+    <h3>Embedded Policy Notes</h3>
+    <p>
+        Compliance verification is required before each release candidate enters production.
+        Teams must maintain up-to-date compliance records, review all outstanding policy exceptions,
+        and confirm that audit evidence is complete and approved.
+    </p>
+    <p>
+        The compliance checklist should cover security controls, data retention policies,
+        and mandatory training acknowledgements for all assigned personnel.
+    </p>
+    <p class="note">
+        This content is served as a same-origin static resource to demonstrate that
+        <code>pe:markText</code> with <code>iframes="true"</code> can highlight search terms
+        inside embedded iframe documents on the same origin.
+    </p>
+</body>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/iframeSupport.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/iframeSupport.xhtml
@@ -1,0 +1,39 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MarkText - Iframes"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates iframe-aware highlighting. The MarkText component can search inside same-origin iframe documents
+            when <code>iframes</code> is enabled. Use <code>iframesTimeout</code> to control how long the search waits
+            for frame content before continuing.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/marktext/example-iframeSupport.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+                ${showcase:getFileContent('/sections/marktext/example-iframeSupport.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/IframeMarkTextController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/marktext/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="markText"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/iframeSupportDocument.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/iframeSupportDocument.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
+<ui:composition>
+    <h:outputStylesheet>
+        body {
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            color: #111827;
+            margin: 0;
+            padding: 12px;
+            line-height: 1.45;
+            background: #f9fafb;
+        }
+
+        .policy-title {
+            font-weight: 700;
+            margin: 0 0 8px;
+            color: #0f172a;
+        }
+
+        .policy-note {
+            margin: 8px 0 0;
+            color: #374151;
+            font-size: 0.95rem;
+        }
+    </h:outputStylesheet>
+
+    <h3 class="policy-title">Embedded Policy Notes</h3>
+    <p>
+        Compliance verification is required before each release candidate enters production.
+        Teams should maintain compliance records, review policy exceptions, and confirm audit evidence.
+    </p>
+    <p class="policy-note">
+        This same-origin content is intentionally embedded for MarkText iframe search demonstration.
+    </p>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
@@ -35,6 +35,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('acrossElements')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/marktext/acrossElements.jsf"/>
+        <p:menuitem value="Iframes"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('iframeSupport')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/marktext/iframeSupport.jsf"/>
         <p:menuitem value="Exclude Selectors"
                 styleClass="#{navigationContext.getMenuitemStyleClass('exclude')}"
                 onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"


### PR DESCRIPTION
Resolve: #2447 

http://localhost:8080/showcase/sections/marktext/iframeSupport.jsf


With iframe search enabled:

<img width="907" height="551" alt="image" src="https://github.com/user-attachments/assets/536ca27d-e5dd-4379-8c28-deb2bc0af7ba" />


---

Without iframe search:

<img width="875" height="563" alt="image" src="https://github.com/user-attachments/assets/c5a09662-5f73-4627-b672-19a2ce06233a" />
