### PR TITLE
Implement new MeterGroup component (#2436)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -221,6 +221,7 @@
                                 <include>timer/**</include>
                                 <include>tooltip/**</include>
                                 <include>waypoint/**</include>
+                                <include>metergroup/**</include>
                             </includes>
                             <aggregations>
                                 <aggregation>

--- a/core/src/main/java/org/primefaces/extensions/component/metergroup/MeterGroup.java
+++ b/core/src/main/java/org/primefaces/extensions/component/metergroup/MeterGroup.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.component.metergroup;
+
+import jakarta.faces.application.ResourceDependency;
+import jakarta.faces.component.FacesComponent;
+
+/**
+ * <code>MeterGroup</code> component.
+ *
+ * @since 16.0.0
+ */
+@FacesComponent(value = MeterGroupBase.COMPONENT_TYPE, namespace = MeterGroupBase.COMPONENT_FAMILY)
+@ResourceDependency(library = org.primefaces.extensions.util.Constants.LIBRARY, name = "metergroup/metergroup.css")
+public class MeterGroup extends MeterGroupBaseImpl {
+
+}

--- a/core/src/main/java/org/primefaces/extensions/component/metergroup/MeterGroupBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/metergroup/MeterGroupBase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.component.metergroup;
+
+import jakarta.faces.component.UIComponentBase;
+
+import org.primefaces.cdk.api.FacesComponentBase;
+import org.primefaces.cdk.api.Property;
+import org.primefaces.component.api.StyleAware;
+import org.primefaces.component.api.Widget;
+
+/**
+ * <code>MeterGroup</code> component.
+ *
+ * @since 16.0.0
+ */
+@FacesComponentBase
+public abstract class MeterGroupBase extends UIComponentBase implements Widget, StyleAware {
+
+    public static final String COMPONENT_TYPE = "org.primefaces.extensions.component.MeterGroup";
+    public static final String COMPONENT_FAMILY = "org.primefaces.extensions.component";
+    public static final String DEFAULT_RENDERER = "org.primefaces.extensions.component.MeterGroupRenderer";
+
+    public MeterGroupBase() {
+        setRendererType(DEFAULT_RENDERER);
+    }
+
+    @Override
+    public String getFamily() {
+        return COMPONENT_FAMILY;
+    }
+
+    @Property(description = "A list of meter items (MeterGroupItem).", required = true)
+    public abstract Object getValue();
+
+    @Property(defaultValue = "0.0", description = "Min value of the meter.")
+    public abstract double getMin();
+
+    @Property(defaultValue = "0.0", description = "Max value of the meter. If 0, defaults to 100 or sum of values.")
+    public abstract double getMax();
+
+    @Property(defaultValue = "horizontal", description = "Orientation of the meter. Valid values: horizontal, vertical.")
+    public abstract String getOrientation();
+
+    @Property(defaultValue = "end", description = "Position of the labels relative to the meters. Valid values: start, end.")
+    public abstract String getLabelPosition();
+
+    @Property(defaultValue = "horizontal", description = "Orientation of the labels. Valid values: horizontal, vertical.")
+    public abstract String getLabelOrientation();
+
+    @Property(defaultValue = "true", description = "Whether to show the labels.")
+    public abstract boolean isShowLabels();
+
+}

--- a/core/src/main/java/org/primefaces/extensions/component/metergroup/MeterGroupRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/metergroup/MeterGroupRenderer.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.component.metergroup;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.ResponseWriter;
+import jakarta.faces.render.FacesRenderer;
+
+import org.primefaces.extensions.model.metergroup.MeterGroupItem;
+import org.primefaces.renderkit.CoreRenderer;
+
+@FacesRenderer(rendererType = MeterGroup.DEFAULT_RENDERER, componentFamily = MeterGroup.COMPONENT_FAMILY)
+public class MeterGroupRenderer extends CoreRenderer<MeterGroup> {
+
+    @Override
+    public void encodeEnd(FacesContext context, MeterGroup component) throws IOException {
+        encodeMarkup(context, component);
+    }
+
+    protected void encodeMarkup(FacesContext context, MeterGroup meterGroup) throws IOException {
+        ResponseWriter writer = context.getResponseWriter();
+        String clientId = meterGroup.getClientId(context);
+        String style = meterGroup.getStyle();
+        String orientation = meterGroup.getOrientation();
+        String labelPosition = meterGroup.getLabelPosition();
+
+        String styleClass = getStyleClassBuilder(context)
+                    .add("ui-metergroup", meterGroup.getStyleClass())
+                    .add("vertical".equals(orientation), " ui-metergroup-vertical", "ui-metergroup-horizontal")
+                    .build();
+
+        writer.startElement("div", meterGroup);
+        writer.writeAttribute("id", clientId, "id");
+        writer.writeAttribute("class", styleClass, "styleClass");
+        if (style != null) {
+            writer.writeAttribute("style", style, "style");
+        }
+
+        Collection<MeterGroupItem> value = (Collection<MeterGroupItem>) meterGroup.getValue();
+
+        if (value != null && !value.isEmpty()) {
+            if ("start".equals(labelPosition) && meterGroup.isShowLabels()) {
+                encodeLabels(context, meterGroup, value);
+            }
+
+            encodeMeters(context, meterGroup, value);
+
+            if ("end".equals(labelPosition) && meterGroup.isShowLabels()) {
+                encodeLabels(context, meterGroup, value);
+            }
+        }
+
+        writer.endElement("div");
+    }
+
+    protected void encodeMeters(FacesContext context, MeterGroup meterGroup, Collection<MeterGroupItem> value)
+                throws IOException {
+        ResponseWriter writer = context.getResponseWriter();
+
+        double total = 0;
+        for (MeterGroupItem item : value) {
+            total += item.getValue();
+        }
+
+        double max = meterGroup.getMax();
+        if (max == 0.0) {
+            max = Math.max(100.0, total);
+        }
+
+        writer.startElement("div", null);
+        writer.writeAttribute("class", "ui-metergroup-meters", null);
+
+        for (MeterGroupItem item : value) {
+            double percent = (item.getValue() / max) * 100.0;
+            // Bound it to avoid overflowing
+            percent = Math.min(100.0, Math.max(0.0, percent));
+
+            writer.startElement("span", null);
+            writer.writeAttribute("class", "ui-metergroup-meter", null);
+
+            String widthHeightSpanAttr = "horizontal".equals(meterGroup.getOrientation()) ? "width" : "height";
+            String style = widthHeightSpanAttr + ": " + percent + "%;";
+            if (item.getColor() != null) {
+                style += " background-color: " + item.getColor() + ";";
+            }
+            writer.writeAttribute("style", style, null);
+
+            writer.endElement("span");
+        }
+
+        writer.endElement("div");
+    }
+
+    protected void encodeLabels(FacesContext context, MeterGroup meterGroup, Collection<MeterGroupItem> value)
+                throws IOException {
+        ResponseWriter writer = context.getResponseWriter();
+        String labelOrientation = meterGroup.getLabelOrientation();
+
+        double total = 0;
+        for (MeterGroupItem item : value) {
+            total += item.getValue();
+        }
+
+        double max = meterGroup.getMax();
+        if (max == 0.0) {
+            max = Math.max(100.0, total);
+        }
+
+        writer.startElement("ul", null);
+        String labelListClass = "ui-metergroup-labels";
+        if ("vertical".equals(labelOrientation)) {
+            labelListClass += " ui-metergroup-labels-vertical";
+        }
+        else {
+            labelListClass += " ui-metergroup-labels-horizontal";
+        }
+        writer.writeAttribute("class", labelListClass, null);
+
+        for (MeterGroupItem item : value) {
+            writer.startElement("li", null);
+            writer.writeAttribute("class", "ui-metergroup-label", null);
+
+            if (item.getIcon() != null) {
+                writer.startElement("i", null);
+                writer.writeAttribute("class", "ui-metergroup-label-icon " + item.getIcon(), null);
+                if (item.getColor() != null) {
+                    writer.writeAttribute("style", "color: " + item.getColor() + ";", null);
+                }
+                writer.endElement("i");
+            }
+            else if (item.getColor() != null) {
+                writer.startElement("span", null);
+                writer.writeAttribute("class", "ui-metergroup-label-color", null);
+                writer.writeAttribute("style", "background-color: " + item.getColor() + ";", null);
+                writer.endElement("span");
+            }
+
+            writer.startElement("span", null);
+            writer.writeAttribute("class", "ui-metergroup-label-text", null);
+
+            double percent = (item.getValue() / max) * 100.0;
+            String text = "";
+            if (item.getLabel() != null) {
+                text += item.getLabel() + " ";
+            }
+            text += "(" + Math.round(percent) + "%)";
+            writer.writeText(text, null);
+
+            writer.endElement("span");
+
+            writer.endElement("li");
+        }
+
+        writer.endElement("ul");
+    }
+}

--- a/core/src/main/java/org/primefaces/extensions/model/metergroup/MeterGroupItem.java
+++ b/core/src/main/java/org/primefaces/extensions/model/metergroup/MeterGroupItem.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.model.metergroup;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Model class for the MeterGroup item.
+ *
+ * @since 16.0.0
+ */
+public class MeterGroupItem implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String label;
+    private double value;
+    private String color;
+    private String icon;
+
+    public MeterGroupItem() {
+        // default constructor
+    }
+
+    public MeterGroupItem(String label, double value) {
+        this.label = label;
+        this.value = value;
+    }
+
+    public MeterGroupItem(String label, double value, String color) {
+        this(label, value);
+        this.color = color;
+    }
+
+    public MeterGroupItem(String label, double value, String color, String icon) {
+        this(label, value, color);
+        this.icon = icon;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MeterGroupItem that = (MeterGroupItem) o;
+        return Double.compare(that.value, value) == 0 &&
+                    Objects.equals(label, that.label) &&
+                    Objects.equals(color, that.color) &&
+                    Objects.equals(icon, that.icon);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(label, value, color, icon);
+    }
+}

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/metergroup/metergroup.css
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/metergroup/metergroup.css
@@ -1,0 +1,78 @@
+.ui-metergroup {
+    display: flex;
+    gap: 1rem;
+}
+
+.ui-metergroup-horizontal {
+    flex-direction: column;
+}
+
+.ui-metergroup-vertical {
+    flex-direction: row;
+}
+
+.ui-metergroup-meters {
+    display: flex;
+    border-radius: 6px;
+    overflow: hidden;
+    background: #e5e7eb;
+}
+
+.ui-metergroup-horizontal .ui-metergroup-meters {
+    height: 0.5rem;
+    flex-direction: row;
+}
+
+.ui-metergroup-vertical .ui-metergroup-meters {
+    width: 0.5rem;
+    flex-direction: column;
+    height: 100%;
+}
+
+.ui-metergroup-meter {
+    transition: width 0.5s ease-in-out, height 0.5s ease-in-out;
+}
+
+.ui-metergroup-horizontal .ui-metergroup-meter {
+    height: 100%;
+}
+
+.ui-metergroup-vertical .ui-metergroup-meter {
+    width: 100%;
+}
+
+.ui-metergroup-labels {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    gap: 1rem;
+}
+
+.ui-metergroup-labels-vertical {
+    flex-direction: column;
+}
+
+.ui-metergroup-labels-horizontal {
+    flex-direction: row;
+}
+
+.ui-metergroup-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.ui-metergroup-label-icon,
+.ui-metergroup-label-color {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.ui-metergroup-label-color {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+}

--- a/showcase/pom.xml
+++ b/showcase/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <primefaces-extensions.core.version>${project.version}</primefaces-extensions.core.version>
-        <primefaces-extensions.new-components>echart;osmap;marktext</primefaces-extensions.new-components>
+        <primefaces-extensions.new-components>echart;osmap;marktext;meterGroup</primefaces-extensions.new-components>
         <primefaces-extensions.updated-components>inputPhone;monacoEditor;orgchart</primefaces-extensions.updated-components>
         <primefaces-extensions.deprecated-components/>
         <jetty.version>12.1.8</jetty.version>

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/MeterGroupController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/MeterGroupController.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import org.primefaces.extensions.model.metergroup.MeterGroupItem;
+
+@Named
+@ViewScoped
+public class MeterGroupController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<MeterGroupItem> meters;
+
+    @PostConstruct
+    public void init() {
+        meters = new ArrayList<>();
+        meters.add(new MeterGroupItem("Apps", 16, "#34d399", "pi pi-cog"));
+        meters.add(new MeterGroupItem("Messages", 8, "#fbbf24", "pi pi-inbox"));
+        meters.add(new MeterGroupItem("Media", 24, "#60a5fa", "pi pi-image"));
+        meters.add(new MeterGroupItem("System", 10, "#c084fc", "pi pi-desktop"));
+    }
+
+    public List<MeterGroupItem> getMeters() {
+        return meters;
+    }
+}

--- a/showcase/src/main/webapp/sections/metergroup/basicUsage.xhtml
+++ b/showcase/src/main/webapp/sections/metergroup/basicUsage.xhtml
@@ -1,0 +1,39 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+    <ui:composition template="/templates/showcaseLayout.xhtml">
+        <ui:define name="centerContent">
+            <f:facet name="header">
+                <h:outputText value="MeterGroup"/>
+            </f:facet>
+            <h:panelGroup layout="block" styleClass="centerContent">
+                Basic usage examples of MeterGroup component demonstrating horizontal, vertical layouts and icon labels.
+            </h:panelGroup>
+
+            <h:panelGroup layout="block" styleClass="centerExample">
+                <ui:include src="/sections/metergroup/example-basicUsage.xhtml"/>
+            </h:panelGroup>
+
+            <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+                <ui:define name="contentTab1">
+                    ${showcase:getFileContent('/sections/metergroup/example-basicUsage.xhtml')}
+                </ui:define>
+                <ui:define name="contentTab2">
+                    ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/MeterGroupController.java')}
+                </ui:define>
+            </ui:decorate>
+        </ui:define>
+
+        <ui:define name="useCases">
+            <ui:include src="/sections/metergroup/useCasesChoice.xhtml"/>
+        </ui:define>
+
+        <ui:define name="docuTable">
+            <ui:include src="/sections/shared/documentation.xhtml">
+                <ui:param name="tagName" value="meterGroup"/>
+            </ui:include>
+        </ui:define>
+    </ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/metergroup/example-basicUsage.xhtml
+++ b/showcase/src/main/webapp/sections/metergroup/example-basicUsage.xhtml
@@ -1,0 +1,31 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:f="jakarta.faces.core"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+
+    <p:growl id="growl" showDetail="true" showSummary="true"/>
+
+    <div class="card">
+        <h3>Basic</h3>
+        <pe:meterGroup value="#{meterGroupController.meters}" />
+    </div>
+
+    <div class="card">
+        <h3>Vertical</h3>
+        <pe:meterGroup value="#{meterGroupController.meters}" orientation="vertical" style="height: 300px" />
+    </div>
+
+    <div class="card">
+        <h3>Labels at Start</h3>
+        <pe:meterGroup value="#{meterGroupController.meters}" labelPosition="start" />
+    </div>
+
+    <div class="card">
+        <h3>Vertical Labels</h3>
+        <pe:meterGroup value="#{meterGroupController.meters}" labelOrientation="vertical" />
+    </div>
+
+</ui:composition>

--- a/showcase/src/main/webapp/sections/metergroup/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/metergroup/useCasesChoice.xhtml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:p="primefaces">
+    <ui:composition>
+        <p:menu id="useCaseMenu">
+            <p:menuitem value="Basic Usage"
+                        styleClass="#{navigationContext.getMenuitemStyleClass('basicUsage')}"
+                        onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                        url="#{request.contextPath}/sections/metergroup/basicUsage.jsf"/>
+        </p:menu>
+    </ui:composition>
+</html>

--- a/showcase/src/main/webapp/templates/showcaseLayout.xhtml
+++ b/showcase/src/main/webapp/templates/showcaseLayout.xhtml
@@ -125,6 +125,9 @@
                 <p:menuitem value="MasterDetail" styleClass="#{navigationContext.getMenuitemStyleClass('masterDetail')}"
                             icon="#{technicalInfo.getMenuitemIconStyleClass('masterDetail')}"
                             onclick="Showcase.selectComponentLink(this)" ajax="false" url="#{request.contextPath}/views/masterDetail.jsf"/>
+                <p:menuitem value="MeterGroup" styleClass="#{navigationContext.getMenuitemStyleClass('meterGroup')}"
+                            icon="#{technicalInfo.getMenuitemIconStyleClass('meterGroup')}"
+                            onclick="Showcase.selectComponentLink(this)" ajax="false" url="#{request.contextPath}/views/meterGroup.jsf"/>
                 <p:menuitem value="MonacoEditor" styleClass="#{navigationContext.getMenuitemStyleClass('monacoEditor')}"
                             icon="#{technicalInfo.getMenuitemIconStyleClass('monacoEditor')}"
                             onclick="Showcase.selectComponentLink(this)" ajax="false" url="#{request.contextPath}/views/monacoEditor.jsf"/>

--- a/showcase/src/main/webapp/views/meterGroup.xhtml
+++ b/showcase/src/main/webapp/views/meterGroup.xhtml
@@ -1,0 +1,31 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:p="primefaces">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MeterGroup" />
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            MeterGroup is a component to visualize data spread as a progress bar.
+            <p/>
+            <strong>Features include:</strong>
+            <ul>
+                <li>Displaying multiple segments in a single bar</li>
+                <li>Horizontal and vertical orientation</li>
+                <li>Configurable labels with icons or colors</li>
+            </ul>
+        </h:panelGroup>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/metergroup/useCasesChoice.xhtml" />
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="meterGroup" />
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>


### PR DESCRIPTION
This PR implements a MeterGroup component, based on [PrimeNG's one](https://primeng.org/metergroup).

I opened the PR here because I already started the development, but if you think the component is better suited in PrimeFaces main repo I may try to implement it there (not sure when 16.0 it's going to be released?).

Here's a screenshot from the showcase:

<img width="1220" height="806" alt="image" src="https://github.com/user-attachments/assets/2dd37dbf-28c7-48d6-98fb-662532f3d95b" />

NB: the development was aided by Google Antigravity

fixes #2436 