### PR TITLE
#2474: Search (MarkText): Client side done callback

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextBase.java
@@ -96,4 +96,7 @@ public abstract class MarkTextBase extends UIComponentBase implements Widget, St
 
     @Property(description = "Whether accented and unaccented letters are treated as the same during matching.", defaultValue = "true")
     public abstract Boolean getDiacritics();
+
+    @Property(description = "Client-side callback executed after marking is complete. The callback receives totalMatches as a parameter.")
+    public abstract String getOnDone();
 }

--- a/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/marktext/MarkTextRenderer.java
@@ -30,6 +30,7 @@ import jakarta.faces.render.FacesRenderer;
 
 import org.primefaces.extensions.util.Attrs;
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 
 import com.google.gson.Gson;
@@ -93,6 +94,10 @@ public class MarkTextRenderer extends CoreRenderer<MarkText> {
                 gson = new Gson();
             }
             wb.nativeAttr("exclude", gson.toJson(component.getExclude()));
+        }
+
+        if (LangUtils.isNotBlank(component.getOnDone())) {
+            wb.callback("onDone", "function(totalMatches)", component.getOnDone());
         }
 
         encodeClientBehaviors(context, component);

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
@@ -39,7 +39,9 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
      */
     refresh(cfg) {
         this._cleanUp();
+        this.value = cfg.value;
         super.refresh(cfg);
+        this._initMark();
     }
 
     /**
@@ -112,6 +114,9 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
                     },
                     done: function(totalMatches) {
                         $this.jq.trigger('marktext.mark', [matchedTerms, positions]);
+                        if ($this.cfg.onDone) {
+                            $this.cfg.onDone(totalMatches);
+                        }
                     }
                 };
 

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/marktext.js
@@ -39,9 +39,7 @@ PrimeFaces.widget.ExtMarkText = class extends PrimeFaces.widget.BaseWidget {
      */
     refresh(cfg) {
         this._cleanUp();
-        this.value = cfg.value;
         super.refresh(cfg);
-        this._initMark();
     }
 
     /**

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/MarkTextDoneController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/MarkTextDoneController.java
@@ -30,7 +30,6 @@ import jakarta.inject.Named;
  * MarkText Done Callback Controller.
  * 
  * @author jxmai
- *
  * @since 16.0.0
  */
 @Named

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/MarkTextDoneController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/marktext/MarkTextDoneController.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.marktext;
+
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+/**
+ * MarkText Done Callback Controller.
+ * 
+ * @author jxmai
+ *
+ * @since 16.0.0
+ */
+@Named
+@ViewScoped
+public class MarkTextDoneController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String searchTerm = "lorem";
+
+    private String processedText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                + " Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                + " Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+                + " Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+    public String getSearchTerm() {
+        return searchTerm;
+    }
+
+    public void setSearchTerm(String searchTerm) {
+        this.searchTerm = searchTerm;
+    }
+
+    public String getProcessedText() {
+        return processedText;
+    }
+
+    public void setProcessedText(String processedText) {
+        this.processedText = processedText;
+    }
+}

--- a/showcase/src/main/webapp/sections/marktext/doneCallback.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/doneCallback.xhtml
@@ -1,0 +1,39 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="MarkText - Done Callback"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Demonstrates the <strong>onDone</strong> client-side callback, which fires after mark.js completes marking. The callback receives the total number of matches as a parameter.
+            <p/>
+            Compare with the <strong>Update Search</strong> example: <em>update search</em> uses a server-side <code>p:ajax event="mark"</code> listener that receives full match data (matched terms and positions) via a server round-trip, while this <em>done callback</em> is purely client-side using the <code>onDone</code> attribute with no Ajax request and receives only the total match count.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/marktext/example-doneCallback.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+                ${showcase:getFileContent('/sections/marktext/example-doneCallback.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+                ${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/marktext/MarkTextDoneController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/marktext/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="markText"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/marktext/example-doneCallback.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-doneCallback.xhtml
@@ -5,10 +5,6 @@
         xmlns:p="primefaces"
         xmlns:pe="primefaces.extensions">
 
-    <p:messages id="messages" showSummary="true" showDetail="true">
-        <p:autoUpdate/>
-    </p:messages>
-
     <style>
         .marktext-highlight {
             background-color: yellow !important;
@@ -32,9 +28,8 @@
     <!-- EXAMPLE-SOURCE-START -->
     <h:panelGrid columns="2">
         <h:outputText value="Search term:"/>
-        <p:inputText id="searchInput" value="#{markTextDoneController.searchTerm}" placeholder="Enter search term">
-            <p:ajax event="keyup" delay="300" update="markText" process="@this"/>
-        </p:inputText>
+        <p:inputText id="doneSearchInput" value="#{markTextDoneController.searchTerm}" placeholder="Enter search term"
+                     onkeyup="PF('markTextWvDone').updateMark(this.value)"/>
     </h:panelGrid>
 
     <p:panel id="searchContainer" header="Searchable Content" style="margin-top: 20px">
@@ -48,7 +43,7 @@
         <h:outputText id="doneCount" value="0"/>
     </p:panel>
 
-    <pe:markText id="markText" for="searchContainer" value="#{markTextDoneController.searchTerm}"
+    <pe:markText id="markText" widgetVar="markTextWvDone" for="searchContainer" value="#{markTextDoneController.searchTerm}"
                  styleClass="marktext-highlight" caseSensitive="false"
                  onDone="markDone(totalMatches)"/>
     <!-- EXAMPLE-SOURCE-END -->

--- a/showcase/src/main/webapp/sections/marktext/example-doneCallback.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/example-doneCallback.xhtml
@@ -1,0 +1,55 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+
+    <p:messages id="messages" showSummary="true" showDetail="true">
+        <p:autoUpdate/>
+    </p:messages>
+
+    <style>
+        .marktext-highlight {
+            background-color: yellow !important;
+            color: black !important;
+        }
+        mark {
+            background-color: yellow !important;
+            color: black !important;
+        }
+    </style>
+
+    <script type="text/javascript">
+        function markDone(totalMatches) {
+            document.getElementById('doneCount').textContent = totalMatches;
+            document.getElementById('doneLabel').textContent = totalMatches === 0
+                ? 'No matches found.'
+                : 'Marking complete: ' + totalMatches + ' match' + (totalMatches !== 1 ? 'es' : '') + ' highlighted.';
+        }
+    </script>
+
+    <!-- EXAMPLE-SOURCE-START -->
+    <h:panelGrid columns="2">
+        <h:outputText value="Search term:"/>
+        <p:inputText id="searchInput" value="#{markTextDoneController.searchTerm}" placeholder="Enter search term">
+            <p:ajax event="keyup" delay="300" update="markText" process="@this"/>
+        </p:inputText>
+    </h:panelGrid>
+
+    <p:panel id="searchContainer" header="Searchable Content" style="margin-top: 20px">
+        <p>#{markTextDoneController.processedText}</p>
+    </p:panel>
+
+    <p:panel id="donePanel" header="Done Callback Result" style="margin-top: 20px">
+        <h:outputText id="doneLabel" value="No search performed yet." />
+        <br/>
+        <h:outputText value="Total matches: "/>
+        <h:outputText id="doneCount" value="0"/>
+    </p:panel>
+
+    <pe:markText id="markText" for="searchContainer" value="#{markTextDoneController.searchTerm}"
+                 styleClass="marktext-highlight" caseSensitive="false"
+                 onDone="markDone(totalMatches)"/>
+    <!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/marktext/useCasesChoice.xhtml
@@ -47,6 +47,10 @@
                 styleClass="#{navigationContext.getMenuitemStyleClass('wildcardSearch')}"
                 onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                 url="#{request.contextPath}/sections/marktext/wildcard.jsf"/>
+        <p:menuitem value="Done Callback"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('doneCallback')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/marktext/doneCallback.jsf"/>
         <p:menuitem value="Advanced Features"
                     styleClass="#{navigationContext.getMenuitemStyleClass('advancedFeatures')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"


### PR DESCRIPTION
Resolve: #2474

Note: https://github.com/primefaces-extensions/primefaces-extensions/blob/307e607ebfc43753d383b122d22386e75687b9c6/core/src/main/resources/META-INF/resources/primefaces-extensions/mark/mark.js#L1112-L1113

Note: totalMatches is the official hardcoded var in markJS, our implementation needs to respect that.

---

http://localhost:8080/showcase/sections/marktext/doneCallback.jsf


<img width="881" height="386" alt="image" src="https://github.com/user-attachments/assets/6b44653e-61d3-46ef-a485-bba3830b32b1" />


