### PR TITLE
#1740: FluidGrid - dynamically replaced items shows the same label on form submitted

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/api/AbstractDynamicData.java
+++ b/core/src/main/java/org/primefaces/extensions/component/api/AbstractDynamicData.java
@@ -542,7 +542,7 @@ public abstract class AbstractDynamicData extends UIComponentBase implements Nam
             }
 
             if (state == null) {
-                state = saved.get(clientId);
+                state = saved.get(id);
 
                 if (state == null) {
                     state = new SavedEditableValueState();
@@ -600,7 +600,7 @@ public abstract class AbstractDynamicData extends UIComponentBase implements Nam
             input.setValid(state.isValid());
             input.setSubmittedValue(state.getSubmittedValue());
             input.setLocalValueSet(state.isLocalValueSet());
-            if (state.getLabelValue() != null) {
+            if (state.getLabelValue() != null && component.getValueExpression(Attrs.LABEL) == null) {
                 ((UIComponent) input).getAttributes().put(Attrs.LABEL, state.getLabelValue());
             }
 

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/fluidgrid/FluidGridDynamicLabelsController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/fluidgrid/FluidGridDynamicLabelsController.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.fluidgrid;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import org.primefaces.extensions.model.fluidgrid.FluidGridItem;
+
+@Named
+@ViewScoped
+public class FluidGridDynamicLabelsController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static int counter = 0;
+
+    private List<FluidGridItem> items;
+
+    @PostConstruct
+    protected void initialize() {
+        items = createItems("First", "Second", "Third", "Fourth", "Fifth");
+    }
+
+    public List<FluidGridItem> getItems() {
+        return items;
+    }
+
+    public void changeItems() {
+        counter++;
+        switch (counter % 3) {
+            case 1:
+                items = createItems("Alpha", "Beta", "Gamma");
+                break;
+            case 2:
+                items = createItems("Apple", "Banana", "Cherry", "Date");
+                break;
+            default:
+                items = createItems("First", "Second", "Third", "Fourth", "Fifth");
+                break;
+        }
+    }
+
+    private static List<FluidGridItem> createItems(String... names) {
+        final List<FluidGridItem> items = new ArrayList<>();
+        for (int i = 0; i < names.length; i++) {
+            final boolean required = i % 2 == 0;
+            items.add(new FluidGridItem(new DynamicLabelField(names[i], null, required), "input"));
+        }
+        return items;
+    }
+
+    public static class DynamicLabelField implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String label;
+        private String value;
+        private boolean required;
+
+        public DynamicLabelField() {
+        }
+
+        public DynamicLabelField(String label, String value, boolean required) {
+            this.label = label;
+            this.value = value;
+            this.required = required;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        public void setRequired(boolean required) {
+            this.required = required;
+        }
+    }
+}

--- a/showcase/src/main/webapp/sections/fluidgrid/dynamiclabels.xhtml
+++ b/showcase/src/main/webapp/sections/fluidgrid/dynamiclabels.xhtml
@@ -1,0 +1,93 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:p="primefaces"
+      xmlns:pe="primefaces.extensions"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="FluidGrid"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            FluidGrid allows to set up a nice tight grid with items that have variable heights and widths.
+            FluidGrid is a responsive grid. That means, the grid will reflow as the window size changes.
+            Items can have any content: text, images, links, input fields, etc.
+            They can be defined in a static or in a dynamic way as in data iteration components.
+            <p/>
+            This example demonstrates dynamic items whose <strong>label</strong> attribute on input
+            components is bound to the data model via the <strong>var</strong> variable.
+            The <strong>Change Items</strong> button dynamically replaces the grid's items to verify
+            that labels are correctly preserved across dynamic updates.
+            <p/>
+            Click <strong>Submit</strong> with empty required fields to see that each validation
+            message correctly displays its own component's label — not the label of the last item.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <!-- EXAMPLE-SOURCE-START -->
+            <p:growl id="growl" showDetail="true" showSummary="true">
+                <p:autoUpdate/>
+            </p:growl>
+
+            <p:commandButton value="Change Items" action="#{fluidGridDynamicLabelsController.changeItems}"
+                             process="@this" update="fluidGrid" style="margin-bottom:10px"/>
+
+            <pe:fluidGrid id="fluidGrid" value="#{fluidGridDynamicLabelsController.items}" var="data"
+                          resizeBound="false" hGutter="20" style="width:450px">
+                <pe:fluidGridItem type="input">
+                    <div class="dynLabel">
+                        <p:outputLabel for="txt" value="#{data.label}"/>
+                    </div>
+                    <p:inputText id="txt" value="#{data.value}" label="#{data.label}" required="#{data.required}"/>
+                </pe:fluidGridItem>
+            </pe:fluidGrid>
+
+            <p:commandButton value="Submit" style="margin-top: 10px;"
+                             process="fluidGrid" update="fluidGrid"
+                             oncomplete="if(!args.validationFailed) {PF('inputValuesWidget').show();}"/>
+
+            <p:dialog header="Submitted Values" widgetVar="inputValuesWidget">
+                <p:dataList id="inputValues" value="#{fluidGridDynamicLabelsController.items}" var="item"
+                            style="margin:10px;">
+                    <h:outputText value="#{item.data.label} : #{item.data.value}" style="margin-right:15px;"/>
+                </p:dataList>
+            </p:dialog>
+
+            <h:outputStylesheet id="fluidGridCSS">
+                .pe-fluidgrid-item {
+                    width: 180px;
+                    height: 65px;
+                }
+                .pe-fluidgrid-item input {
+                    width: 170px;
+                }
+                .dynLabel {
+                    font-weight: bold;
+                    margin-bottom: 5px;
+                }
+            </h:outputStylesheet>
+            <!-- EXAMPLE-SOURCE-END -->
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+${showcase:getFileContent('/sections/fluidgrid/examples/example-dynamiclabels.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/fluidgrid/FluidGridDynamicLabelsController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/fluidgrid/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/twoTabsDocumentation.xhtml">
+            <ui:param name="tagName1" value="fluidGrid"/>
+            <ui:param name="tagName2" value="fluidGridItem"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/fluidgrid/examples/dynamiclabels.xhtml
+++ b/showcase/src/main/webapp/sections/fluidgrid/examples/dynamiclabels.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:pe="primefaces.extensions"
+      xmlns:ui="jakarta.faces.facelets">
+<f:view contentType="text/html" locale="en">
+    <pe:head title="PrimeFaces Extensions" shortcutIcon="#{request.contextPath}/favicon_16x16.png">
+        <f:facet name="first">
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+            <meta http-equiv="pragma" content="no-cache"/>
+            <meta http-equiv="cache-control" content="no-cache"/>
+            <meta http-equiv="expires" content="0"/>
+             <h:outputScript  target="body">
+               document.getElementsByTagName("html")[0].style.visibility = "visible";
+            </h:outputScript>
+        </f:facet>
+    </pe:head>
+    <h:body>
+        <h:form id="mainForm" prependId="false">
+            <ui:include src="/sections/fluidgrid/examples/example-dynamiclabels.xhtml"/>
+        </h:form>
+
+        <h:outputStylesheet library="css" name="global.css"/>
+        <h:outputStylesheet library="css" name="layout.css"/>
+    </h:body>
+</f:view>
+</html>

--- a/showcase/src/main/webapp/sections/fluidgrid/examples/example-dynamiclabels.xhtml
+++ b/showcase/src/main/webapp/sections/fluidgrid/examples/example-dynamiclabels.xhtml
@@ -1,0 +1,50 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="jakarta.faces.html"
+        xmlns:ui="jakarta.faces.facelets"
+        xmlns:p="primefaces"
+        xmlns:pe="primefaces.extensions">
+<!-- EXAMPLE-SOURCE-START -->
+    <p:growl id="growl" showDetail="true" showSummary="true">
+        <p:autoUpdate />
+    </p:growl>
+
+    <p:commandButton value="Change Items" action="#{fluidGridDynamicLabelsController.changeItems}"
+                     process="@this" update="fluidGrid" style="margin-bottom:10px"/>
+
+    <pe:fluidGrid id="fluidGrid" value="#{fluidGridDynamicLabelsController.items}" var="data"
+                  resizeBound="false" hGutter="20" style="width:450px">
+        <pe:fluidGridItem type="input">
+            <div class="dynLabel">
+                <p:outputLabel for="txt" value="#{data.label}"/>
+            </div>
+            <p:inputText id="txt" value="#{data.value}" label="#{data.label}" required="#{data.required}"/>
+        </pe:fluidGridItem>
+    </pe:fluidGrid>
+
+    <p:commandButton value="Submit" style="margin-top: 10px;"
+                     process="fluidGrid" update="fluidGrid"
+                     oncomplete="if(!args.validationFailed) {PF('inputValuesWidget').show();}"/>
+
+    <p:dialog header="Submitted Values" widgetVar="inputValuesWidget">
+        <p:dataList id="inputValues" value="#{fluidGridDynamicLabelsController.items}" var="item"
+                    style="margin:10px;">
+            <h:outputText value="#{item.data.label} : #{item.data.value}" style="margin-right:15px;"/>
+        </p:dataList>
+    </p:dialog>
+
+    <h:outputStylesheet id="fluidGridCSS">
+        .pe-fluidgrid-item {
+            width: 180px;
+            height: 65px;
+        }
+        .pe-fluidgrid-item input {
+            width: 170px;
+        }
+        .dynLabel {
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+    </h:outputStylesheet>
+<!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/fluidgrid/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/fluidgrid/useCasesChoice.xhtml
@@ -19,6 +19,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('dynaform')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/fluidgrid/dynaform.jsf"/>
+        <p:menuitem value="Dynamic labels"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('dynamiclabels')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/fluidgrid/dynamiclabels.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
Resolve #1740 

---

The problem was that when fluidGrid items are dynamically replaced, such as via AJAX, and the form is submitted with the validation errors, all the valiation message shows the same label (The label of the last rendered item), which is clearly bug.

In a deeper dive, there's actually two bugs in [AbstractDynamicData.java](https://github.com/primefaces-extensions/primefaces-extensions/blob/master/core/src/main/java/org/primefaces/extensions/component/api/AbstractDynamicData.java)

### Issue 1: Wrong var in state lookup

https://github.com/primefaces-extensions/primefaces-extensions/blob/63b4a93aaf1d8d567190335d178e71b2f1f1b5a8/core/src/main/java/org/primefaces/extensions/component/api/AbstractDynamicData.java#L545


It uses fluidgrid component's owned cache clientId, 

https://github.com/primefaces-extensions/primefaces-extensions/blob/63b4a93aaf1d8d567190335d178e71b2f1f1b5a8/core/src/main/java/org/primefaces/extensions/component/api/AbstractDynamicData.java#L67

It sets once at here, https://github.com/primefaces-extensions/primefaces-extensions/blob/63b4a93aaf1d8d567190335d178e71b2f1f1b5a8/core/src/main/java/org/primefaces/extensions/component/api/AbstractDynamicData.java#L167-L169

It is the parent's component own cached clientId, as a result `saved.get(clientId)` looks up `form:grid` -> always null -> create new state, which also means the EditableValueHolder creates an empty SaveEditableState instead of updating the one that was stored from the previous save/restore cycle. This is the reason caused label value and other state to be lost rather than preserved across row iterations.

If we change it to `saved.get(id)`, it would look up `form:grid:id` -> finds existing state -> updates


### Issue 2: Label restoration destroys ValueExpression

https://github.com/primefaces-extensions/primefaces-extensions/blob/63b4a93aaf1d8d567190335d178e71b2f1f1b5a8/core/src/main/java/org/primefaces/extensions/component/api/AbstractDynamicData.java#L603-L605


restoreDescendantState called `.getAttributes().put(Attrs.LABEL, state.getLabelValue());`, which replaced the value expression such as `data.label` with a hardcoded string.  Once replaced, all items of the same type see the same literal instead of re-evaluate the the EL per row, so we need to guard it with `component.getValueExpression(Attrs.LABEL) == null`


---

New showcase demo:


http://localhost:8080/showcase/sections/fluidgrid/dynamiclabels.jsf


<img width="1129" height="631" alt="image" src="https://github.com/user-attachments/assets/bb06f3ca-6945-410a-84bf-d17f2d6b8b50" />


<img width="1129" height="631" alt="image" src="https://github.com/user-attachments/assets/79d74f6f-2e0a-4c13-82bc-d43db055b8b8" />

