### PR TITLE
PF 15 Backport #1740: FluidGrid - dynamically replaced items shows the same label on form submitted

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/base/AbstractDynamicData.java
+++ b/core/src/main/java/org/primefaces/extensions/component/base/AbstractDynamicData.java
@@ -563,7 +563,7 @@ public abstract class AbstractDynamicData extends UIComponentBase implements Nam
             }
 
             if (state == null) {
-                state = saved.get(clientId);
+                state = saved.get(id);
 
                 if (state == null) {
                     state = new SavedEditableValueState();
@@ -621,7 +621,7 @@ public abstract class AbstractDynamicData extends UIComponentBase implements Nam
             input.setValid(state.isValid());
             input.setSubmittedValue(state.getSubmittedValue());
             input.setLocalValueSet(state.isLocalValueSet());
-            if (state.getLabelValue() != null) {
+            if (state.getLabelValue() != null && component.getValueExpression(Attrs.LABEL) == null) {
                 ((UIComponent) input).getAttributes().put(Attrs.LABEL, state.getLabelValue());
             }
 

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/fluidgrid/FluidGridDynamicLabelsController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/fluidgrid/FluidGridDynamicLabelsController.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2011-2025 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.fluidgrid;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+import org.primefaces.extensions.model.fluidgrid.FluidGridItem;
+
+@Named
+@ViewScoped
+public class FluidGridDynamicLabelsController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static int counter = 0;
+
+    private List<FluidGridItem> items;
+
+    @PostConstruct
+    protected void initialize() {
+        items = createItems("First", "Second", "Third", "Fourth", "Fifth");
+    }
+
+    public List<FluidGridItem> getItems() {
+        return items;
+    }
+
+    public void changeItems() {
+        counter++;
+        switch (counter % 3) {
+            case 1:
+                items = createItems("Alpha", "Beta", "Gamma");
+                break;
+            case 2:
+                items = createItems("Apple", "Banana", "Cherry", "Date");
+                break;
+            default:
+                items = createItems("First", "Second", "Third", "Fourth", "Fifth");
+                break;
+        }
+    }
+
+    private static List<FluidGridItem> createItems(String... names) {
+        final List<FluidGridItem> items = new ArrayList<>();
+        for (int i = 0; i < names.length; i++) {
+            final boolean required = i % 2 == 0;
+            items.add(new FluidGridItem(new DynamicLabelField(names[i], null, required), "input"));
+        }
+        return items;
+    }
+
+    public static class DynamicLabelField implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String label;
+        private String value;
+        private boolean required;
+
+        public DynamicLabelField() {
+        }
+
+        public DynamicLabelField(String label, String value, boolean required) {
+            this.label = label;
+            this.value = value;
+            this.required = required;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        public void setRequired(boolean required) {
+            this.required = required;
+        }
+    }
+}

--- a/showcase/src/main/webapp/sections/fluidgrid/dynamiclabels.xhtml
+++ b/showcase/src/main/webapp/sections/fluidgrid/dynamiclabels.xhtml
@@ -1,0 +1,93 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:pe="http://primefaces.org/ui/extensions"
+      xmlns:showcase="http://primefaces.org/ui/extensions/showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="FluidGrid"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            FluidGrid allows to set up a nice tight grid with items that have variable heights and widths.
+            FluidGrid is a responsive grid. That means, the grid will reflow as the window size changes.
+            Items can have any content: text, images, links, input fields, etc.
+            They can be defined in a static or in a dynamic way as in data iteration components.
+            <p/>
+            This example demonstrates dynamic items whose <strong>label</strong> attribute on input
+            components is bound to the data model via the <strong>var</strong> variable.
+            The <strong>Change Items</strong> button dynamically replaces the grid's items to verify
+            that labels are correctly preserved across dynamic updates.
+            <p/>
+            Click <strong>Submit</strong> with empty required fields to see that each validation
+            message correctly displays its own component's label — not the label of the last item.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <!-- EXAMPLE-SOURCE-START -->
+            <p:growl id="growl" showDetail="true" showSummary="true">
+                <p:autoUpdate/>
+            </p:growl>
+
+            <p:commandButton value="Change Items" action="#{fluidGridDynamicLabelsController.changeItems}"
+                             process="@this" update="fluidGrid" style="margin-bottom:10px"/>
+
+            <pe:fluidGrid id="fluidGrid" value="#{fluidGridDynamicLabelsController.items}" var="data"
+                          resizeBound="false" hGutter="20" style="width:450px">
+                <pe:fluidGridItem type="input">
+                    <div class="dynLabel">
+                        <p:outputLabel for="txt" value="#{data.label}"/>
+                    </div>
+                    <p:inputText id="txt" value="#{data.value}" label="#{data.label}" required="#{data.required}"/>
+                </pe:fluidGridItem>
+            </pe:fluidGrid>
+
+            <p:commandButton value="Submit" style="margin-top: 10px;"
+                             process="fluidGrid" update="fluidGrid"
+                             oncomplete="if(!args.validationFailed) {PF('inputValuesWidget').show();}"/>
+
+            <p:dialog header="Submitted Values" widgetVar="inputValuesWidget">
+                <p:dataList id="inputValues" value="#{fluidGridDynamicLabelsController.items}" var="item"
+                            style="margin:10px;">
+                    <h:outputText value="#{item.data.label} : #{item.data.value}" style="margin-right:15px;"/>
+                </p:dataList>
+            </p:dialog>
+
+            <h:outputStylesheet id="fluidGridCSS">
+                .pe-fluidgrid-item {
+                    width: 180px;
+                    height: 65px;
+                }
+                .pe-fluidgrid-item input {
+                    width: 170px;
+                }
+                .dynLabel {
+                    font-weight: bold;
+                    margin-bottom: 5px;
+                }
+            </h:outputStylesheet>
+            <!-- EXAMPLE-SOURCE-END -->
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+${showcase:getFileContent('/sections/fluidgrid/examples/example-dynamiclabels.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/fluidgrid/FluidGridDynamicLabelsController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/fluidgrid/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/twoTabsDocumentation.xhtml">
+            <ui:param name="tagName1" value="fluidGrid"/>
+            <ui:param name="tagName2" value="fluidGridItem"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/fluidgrid/examples/dynamiclabels.xhtml
+++ b/showcase/src/main/webapp/sections/fluidgrid/examples/dynamiclabels.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:pe="http://primefaces.org/ui/extensions"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+<f:view contentType="text/html" locale="en">
+    <pe:head title="PrimeFaces Extensions" shortcutIcon="#{request.contextPath}/favicon_16x16.png">
+        <f:facet name="first">
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+            <meta http-equiv="pragma" content="no-cache"/>
+            <meta http-equiv="cache-control" content="no-cache"/>
+            <meta http-equiv="expires" content="0"/>
+             <h:outputScript  target="body">
+               document.getElementsByTagName("html")[0].style.visibility = "visible";
+            </h:outputScript>
+        </f:facet>
+    </pe:head>
+    <h:body>
+        <h:form id="mainForm" prependId="false">
+            <ui:include src="/sections/fluidgrid/examples/example-dynamiclabels.xhtml"/>
+        </h:form>
+
+        <h:outputStylesheet library="css" name="global.css"/>
+        <h:outputStylesheet library="css" name="layout.css"/>
+    </h:body>
+</f:view>
+</html>

--- a/showcase/src/main/webapp/sections/fluidgrid/examples/example-dynamiclabels.xhtml
+++ b/showcase/src/main/webapp/sections/fluidgrid/examples/example-dynamiclabels.xhtml
@@ -1,0 +1,50 @@
+<ui:composition
+        xmlns="http://www.w3.org/1999/xhtml"
+        xmlns:h="http://xmlns.jcp.org/jsf/html"
+        xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+        xmlns:p="http://primefaces.org/ui"
+        xmlns:pe="http://primefaces.org/ui/extensions">
+<!-- EXAMPLE-SOURCE-START -->
+    <p:growl id="growl" showDetail="true" showSummary="true">
+        <p:autoUpdate />
+    </p:growl>
+
+    <p:commandButton value="Change Items" action="#{fluidGridDynamicLabelsController.changeItems}"
+                     process="@this" update="fluidGrid" style="margin-bottom:10px"/>
+
+    <pe:fluidGrid id="fluidGrid" value="#{fluidGridDynamicLabelsController.items}" var="data"
+                  resizeBound="false" hGutter="20" style="width:450px">
+        <pe:fluidGridItem type="input">
+            <div class="dynLabel">
+                <p:outputLabel for="txt" value="#{data.label}"/>
+            </div>
+            <p:inputText id="txt" value="#{data.value}" label="#{data.label}" required="#{data.required}"/>
+        </pe:fluidGridItem>
+    </pe:fluidGrid>
+
+    <p:commandButton value="Submit" style="margin-top: 10px;"
+                     process="fluidGrid" update="fluidGrid"
+                     oncomplete="if(!args.validationFailed) {PF('inputValuesWidget').show();}"/>
+
+    <p:dialog header="Submitted Values" widgetVar="inputValuesWidget">
+        <p:dataList id="inputValues" value="#{fluidGridDynamicLabelsController.items}" var="item"
+                    style="margin:10px;">
+            <h:outputText value="#{item.data.label} : #{item.data.value}" style="margin-right:15px;"/>
+        </p:dataList>
+    </p:dialog>
+
+    <h:outputStylesheet id="fluidGridCSS">
+        .pe-fluidgrid-item {
+            width: 180px;
+            height: 65px;
+        }
+        .pe-fluidgrid-item input {
+            width: 170px;
+        }
+        .dynLabel {
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+    </h:outputStylesheet>
+<!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/fluidgrid/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/fluidgrid/useCasesChoice.xhtml
@@ -19,6 +19,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('dynaform')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/fluidgrid/dynaform.jsf"/>
+        <p:menuitem value="Dynamic labels"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('dynamiclabels')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/fluidgrid/dynamiclabels.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
Backport: #1740 

---

http://localhost:8080/showcase-ext/sections/fluidgrid/dynamiclabels.jsf

<img width="1185" height="485" alt="image" src="https://github.com/user-attachments/assets/f66c304a-ca32-42d2-9dc8-33e737703256" />

---

<img width="1185" height="485" alt="image" src="https://github.com/user-attachments/assets/ffba61ca-d886-4602-9584-67418c151bfb" />
