### PR TITLE
#1233: Sheet: provide access to row value during selection events

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
+++ b/core/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
@@ -147,7 +147,19 @@ public class Sheet extends SheetBaseImpl {
         if (isAjaxBehaviorEventSource(event)) {
             final FacesContext context = event.getFacesContext();
             final AjaxBehaviorEvent behaviorEvent = (AjaxBehaviorEvent) event;
-            final SheetEvent sheetEvent = new SheetEvent(this, behaviorEvent.getBehavior());
+
+            final int rowIndex = getSelectedRow();
+            final int colIndex = getSelectedColumn();
+            Object rowData = null;
+            if (rowIndex >= 0) {
+                final List<Object> values = getSortedValues();
+                if (rowIndex < values.size()) {
+                    rowData = values.get(rowIndex);
+                }
+            }
+
+            final SheetEvent sheetEvent = new SheetEvent(this, behaviorEvent.getBehavior(), rowData, rowIndex,
+                        colIndex);
             sheetEvent.setPhaseId(event.getPhaseId());
             super.queueEvent(sheetEvent);
             return;

--- a/core/src/main/java/org/primefaces/extensions/event/SheetEvent.java
+++ b/core/src/main/java/org/primefaces/extensions/event/SheetEvent.java
@@ -37,11 +37,35 @@ public class SheetEvent extends AbstractAjaxBehaviorEvent {
 
     private static final long serialVersionUID = 1L;
 
+    private transient Object rowData;
+    private int rowIndex = -1;
+    private int columnIndex = -1;
+
     public SheetEvent(final UIComponent component, final Behavior behavior) {
         super(component, behavior);
     }
 
+    public SheetEvent(final UIComponent component, final Behavior behavior, final Object rowData,
+                final int rowIndex, final int columnIndex) {
+        super(component, behavior);
+        this.rowData = rowData;
+        this.rowIndex = rowIndex;
+        this.columnIndex = columnIndex;
+    }
+
     public Sheet getSheet() {
         return (Sheet) getComponent();
+    }
+
+    public Object getRowData() {
+        return rowData;
+    }
+
+    public int getRowIndex() {
+        return rowIndex;
+    }
+
+    public int getColumnIndex() {
+        return columnIndex;
     }
 }

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/sheet/SheetAjaxController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/sheet/SheetAjaxController.java
@@ -34,6 +34,7 @@ import org.apache.commons.collections4.IterableUtils;
 import org.primefaces.extensions.component.sheet.Sheet;
 import org.primefaces.extensions.event.SheetEvent;
 import org.primefaces.extensions.model.sheet.SheetUpdate;
+import org.primefaces.extensions.showcase.model.sheet.Asset;
 
 /**
  * {@link Sheet} Ajax Controller.
@@ -45,6 +46,8 @@ import org.primefaces.extensions.model.sheet.SheetUpdate;
 public class SheetAjaxController extends SheetController {
 
     private static final long serialVersionUID = 20120224L;
+
+    private Asset selectedAsset;
 
     /**
      * Ajax callback from the Sheet component when a cell value is changed.
@@ -79,11 +82,17 @@ public class SheetAjaxController extends SheetController {
     /**
      * Ajax callback from the Sheet component when a row is selected.
      */
-    public static void rowSelectEvent(final SheetEvent event) {
-        final Sheet sheet = event.getSheet();
-        final int row = sheet.getSelectedRow() + 1;
+    public void rowSelectEvent(final SheetEvent event) {
+        selectedAsset = (Asset) event.getRowData();
+        final int row = event.getRowIndex() + 1;
+        final String hostName = (selectedAsset != null) ? selectedAsset.getHostName() : "N/A";
         FacesContext.getCurrentInstance().addMessage(null,
-                    new FacesMessage("Row Selected", String.format("Row %d selected.", row)));
+                    new FacesMessage("Row Selected",
+                                String.format("Row %d selected. Host: %s", row, hostName)));
+    }
+
+    public Asset getSelectedAsset() {
+        return selectedAsset;
     }
 
     public static void validateExactly5(final FacesContext context, final UIComponent comp, final Object value) {

--- a/showcase/src/main/webapp/sections/sheet/example-ajaxEvents.xhtml
+++ b/showcase/src/main/webapp/sections/sheet/example-ajaxEvents.xhtml
@@ -2,11 +2,11 @@
                 xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces"
                 xmlns:pe="primefaces.extensions" xmlns:f="jakarta.faces.core">
 
-    <!-- EXAMPLE-SOURCE-START -->
     <p:growl id="growl" showDetail="true" showSummary="true">
         <p:autoUpdate/>
     </p:growl>
-
+    
+    <!-- EXAMPLE-SOURCE-START -->
     <pe:sheet id="sheet" widgetVar="sheetWidget" value="#{sheetAjaxController.assets}"
               var="row" height="400" rowKey="#{row.assetId}" showRowHeaders="true"
               sortBy="#{row.assetId}" sortOrder="ascending" width="1000"

--- a/showcase/src/main/webapp/sections/sheet/example-ajaxEvents.xhtml
+++ b/showcase/src/main/webapp/sections/sheet/example-ajaxEvents.xhtml
@@ -2,11 +2,11 @@
                 xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces"
                 xmlns:pe="primefaces.extensions" xmlns:f="jakarta.faces.core">
 
+    <!-- EXAMPLE-SOURCE-START -->
     <p:growl id="growl" showDetail="true" showSummary="true">
         <p:autoUpdate/>
     </p:growl>
 
-    <!-- EXAMPLE-SOURCE-START -->
     <pe:sheet id="sheet" widgetVar="sheetWidget" value="#{sheetAjaxController.assets}"
               var="row" height="400" rowKey="#{row.assetId}" showRowHeaders="true"
               sortBy="#{row.assetId}" sortOrder="ascending" width="1000"
@@ -15,7 +15,7 @@
 
         <p:ajax event="change" listener="#{sheetAjaxController.cellChangeEvent}"/>
         <p:ajax event="columnSelect" listener="#{sheetAjaxController.columnSelectEvent}"/>
-        <p:ajax event="rowSelect" listener="#{sheetAjaxController.rowSelectEvent}"/>
+        <p:ajax event="rowSelect" listener="#{sheetAjaxController.rowSelectEvent}" update="detailPanel"/>
 
         <f:facet name="header">
             <h:outputText value="Assets"/>
@@ -33,4 +33,25 @@
     </pe:sheet>
 
     <!-- EXAMPLE-SOURCE-END -->
+
+    <p:panel id="detailPanel" header="Selected Row Details" style="margin-top:1rem">
+        <h:panelGrid columns="2" rendered="#{sheetAjaxController.selectedAsset != null}">
+            <h:outputText value="ID:"/>
+            <h:outputText value="#{sheetAjaxController.selectedAsset.assetId}"/>
+            <h:outputText value="Host Name:"/>
+            <h:outputText value="#{sheetAjaxController.selectedAsset.hostName}"/>
+            <h:outputText value="Platform:"/>
+            <h:outputText value="#{sheetAjaxController.selectedAsset.platform}"/>
+            <h:outputText value="Type:"/>
+            <h:outputText value="#{sheetAjaxController.selectedAsset.assetType}"/>
+            <h:outputText value="Arch:"/>
+            <h:outputText value="#{sheetAjaxController.selectedAsset.platformArch}"/>
+            <h:outputText value="Purchase Price:"/>
+            <h:outputText value="#{sheetAjaxController.selectedAsset.purchasePrice}"/>
+            <h:outputText value="Active:"/>
+            <h:outputText value="#{sheetAjaxController.selectedAsset.active}"/>
+        </h:panelGrid>
+        <h:outputText value="Click a row to see details." rendered="#{sheetAjaxController.selectedAsset == null}"
+                      style="color:#888"/>
+    </p:panel>
 </ui:composition>


### PR DESCRIPTION
Resolve #1233 

Enhance SheetEvent to carry row data alongside selection events, matching the pattern of data driven components.

The previous Ajax event was limited, but now we can retrieve rowData, rowIndex, and columnIndex directly from the event.

Update the showcase to demo the enhanced usage:


http://localhost:8080/showcase/sections/sheet/ajaxEvents.jsf

<img width="1230" height="795" alt="image" src="https://github.com/user-attachments/assets/9356faa4-6e0a-4269-be5c-1c6d2f89cd2e" />
