### PR TITLE
#2136, #591: Sheet column filter steals focus on hover - behavior enhancement

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/sheet/1-sheet.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/sheet/1-sheet.js
@@ -245,8 +245,8 @@ PrimeFaces.widget.ExtSheet = class extends PrimeFaces.widget.DeferredWidget {
                             $this.filterKeyDown($this, e)
                         }).on('keyup.sheetfilter', function (e) {
                             $this.filterKeyUp($this, e)
-                        }).on('mouseover.sheetfilter', function (e) {
-                            $this.filterMouseOver($this, e)
+                        }).on('mousedown.sheetfilter', function (e) {
+                            $this.filterMouseDown($this, e)
                         }).on('focusin.sheetfilter', function () {
                             $this.filterFocusIn($this, this)
                         }).on('focusout.sheetfilter', function () {
@@ -268,8 +268,8 @@ PrimeFaces.widget.ExtSheet = class extends PrimeFaces.widget.DeferredWidget {
                             $this.filterKeyDown($this, e)
                         }).on('keyup.sheetfilter', function (e) {
                             $this.filterKeyUp($this, e)
-                        }).on('mouseover.sheetfilter', function (e) {
-                            $this.filterMouseOver($this, e)
+                        }).on('mousedown.sheetfilter', function (e) {
+                            $this.filterMouseDown($this, e)
                         }).on('focusin.sheetfilter', function () {
                             $this.filterFocusIn($this, this)
                         });
@@ -452,9 +452,14 @@ PrimeFaces.widget.ExtSheet = class extends PrimeFaces.widget.DeferredWidget {
         }
     }
 
-    // to alleviate focus issues focus on mouse over
-    filterMouseOver(sheet, e) {
+    filterMouseDown(sheet, e) {
+        var editor = sheet.ht.getActiveEditor();
+        if (editor && editor.isOpened()) {
+            return;
+        }
+        sheet.focusing = true;
         $(e.target).focus();
+        sheet.focusing = false;
     }
 
     // keep track of focused filter input. if previous filter altered,


### PR DESCRIPTION
Resolve: #2136, https://github.com/primefaces-extensions/primefaces-extensions.github.com/issues/591

The issue was hovering over any filter input immediately stole focus. 

To fix both issues, we need to replace the mouseover workaround with mouse-based approach that works in a single click without hovering regression.

Can verify via: http://localhost:8080/showcase/sections/sheet/basicUsage.jsf

