### PR TITLE
#2514: configure SunEditor v3 exportPDF plugin, update the showcase

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/suneditor/1-suneditor-widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/suneditor/1-suneditor-widget.js
@@ -17,7 +17,7 @@ PrimeFaces.widget.ExtSunEditor = class extends PrimeFaces.widget.DeferredWidget 
         this.disabled = (cfg.disabled === undefined) ? false : cfg.disabled;
         this.cfg.strictMode = (cfg.strictMode === undefined) ? true : cfg.strictMode;
         this.cfg.textDirection = this.cfg.rtl ? "rtl" : "ltr";
-        this.cfg.plugins = Object.assign({}, SUNEDITOR.plugins, this.cfg.plugins);
+        this.cfg.plugins = this.cfg.plugins || SUNEDITOR.plugins;
         this.cfg.v2Migration = true;
 
         this.cfg.exportPDF = {

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/suneditor/1-suneditor-widget.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/suneditor/1-suneditor-widget.js
@@ -17,8 +17,13 @@ PrimeFaces.widget.ExtSunEditor = class extends PrimeFaces.widget.DeferredWidget 
         this.disabled = (cfg.disabled === undefined) ? false : cfg.disabled;
         this.cfg.strictMode = (cfg.strictMode === undefined) ? true : cfg.strictMode;
         this.cfg.textDirection = this.cfg.rtl ? "rtl" : "ltr";
-        this.cfg.plugins = this.cfg.plugins || SUNEDITOR.plugins;
+        this.cfg.plugins = Object.assign({}, SUNEDITOR.plugins, this.cfg.plugins);
         this.cfg.v2Migration = true;
+
+        this.cfg.exportPDF = {
+            apiUrl: this.cfg.exportPDFUrl
+                || (PrimeFaces.settings.contextPath + '/api/suneditor/export-pdf')
+        };
 
         if (this.disabled) {
             this.input.attr("disabled", "disabled");

--- a/showcase/pom.xml
+++ b/showcase/pom.xml
@@ -110,6 +110,12 @@
             <artifactId>openpdf</artifactId>
             <version>1.4.2</version>
         </dependency>
+        <!-- SunEditor Export PDF -->
+        <dependency>
+            <groupId>org.xhtmlrenderer</groupId>
+            <artifactId>flying-saucer-pdf-openpdf</artifactId>
+            <version>9.4.0</version>
+        </dependency>
         <!-- Sanitizing Converter -->
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/suneditor/SunEditorExportPDFServlet.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/suneditor/SunEditorExportPDFServlet.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.suneditor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+/**
+ * Servlet for exporting SunEditor HTML content to PDF. Called by the SunEditor exportPDF plugin.
+ */
+@WebServlet("/api/suneditor/export-pdf")
+public class SunEditorExportPDFServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        request.setCharacterEncoding("UTF-8");
+        response.setContentType("application/pdf");
+
+        Reader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8);
+        StringBuilder sb = new StringBuilder();
+        char[] buf = new char[1024];
+        int len;
+        while ((len = reader.read(buf)) != -1) {
+            sb.append(buf, 0, len);
+        }
+
+        String json = sb.toString();
+        String fileName = "suneditor.pdf";
+        String htmlContent = "";
+
+        // simple JSON parsing to avoid extra dependencies
+        String fileNameKey = "\"fileName\":\"";
+        int fnStart = json.indexOf(fileNameKey);
+        if (fnStart >= 0) {
+            int fnValStart = fnStart + fileNameKey.length();
+            int fnValEnd = json.indexOf("\"", fnValStart);
+            if (fnValEnd > fnValStart) {
+                fileName = json.substring(fnValStart, fnValEnd) + ".pdf";
+            }
+        }
+
+        String htmlKey = "\"htmlContent\":\"";
+        int hcStart = json.indexOf(htmlKey);
+        if (hcStart >= 0) {
+            int hcValStart = hcStart + htmlKey.length();
+            int hcValEnd = json.lastIndexOf("\"}");
+            if (hcValEnd > hcValStart) {
+                htmlContent = json.substring(hcValStart, hcValEnd)
+                            .replace("\\\"", "\"")
+                            .replace("\\n", "\n")
+                            .replace("\\t", "\t")
+                            .replace("\\\\", "\\");
+            }
+        }
+
+        response.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            String xhtml = wrapHTML(htmlContent);
+
+            ITextRenderer renderer = new ITextRenderer();
+            renderer.setDocumentFromString(xhtml);
+            renderer.layout();
+            renderer.createPDF(os);
+            os.flush();
+
+            response.setContentLength(os.size());
+            response.getOutputStream().write(os.toByteArray());
+        }
+        catch (Exception e) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "PDF generation failed: " + e.getMessage());
+        }
+    }
+
+    private String wrapHTML(String content) {
+        int styleEnd = content.indexOf("</style>");
+        String body = styleEnd >= 0 ? content.substring(styleEnd + "</style>".length()) : content;
+
+        return "<!DOCTYPE html>\n<html>\n<head>\n"
+                    + "<meta charset=\"UTF-8\"/>\n"
+                    + "<style>\n"
+                    + "body { font-family: Arial, Helvetica, sans-serif; font-size: 14px; color: #333; }\n"
+                    + "h1 { font-size: 2em; margin: 0.67em 0; }\n"
+                    + "h2 { font-size: 1.5em; margin: 0.83em 0; }\n"
+                    + "h3 { font-size: 1.17em; margin: 1em 0; }\n"
+                    + "p { margin: 0 0 10px; }\n"
+                    + "strong { font-weight: bold; }\n"
+                    + "em { font-style: italic; }\n"
+                    + "table { border-collapse: collapse; width: 100%; }\n"
+                    + "td, th { border: 1px solid #ddd; padding: 8px; }\n"
+                    + "img { max-width: 100%; }\n"
+                    + "</style>\n</head>\n<body>\n"
+                    + body
+                    + "\n</body>\n</html>";
+    }
+}

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/suneditor/SunEditorExportPDFServlet.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/suneditor/SunEditorExportPDFServlet.java
@@ -48,15 +48,17 @@ public class SunEditorExportPDFServlet extends HttpServlet {
         request.setCharacterEncoding("UTF-8");
         response.setContentType("application/pdf");
 
-        Reader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8);
-        StringBuilder sb = new StringBuilder();
-        char[] buf = new char[1024];
-        int len;
-        while ((len = reader.read(buf)) != -1) {
-            sb.append(buf, 0, len);
+        String json;
+        try (Reader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+            StringBuilder sb = new StringBuilder();
+            char[] buf = new char[1024];
+            int len;
+            while ((len = reader.read(buf)) != -1) {
+                sb.append(buf, 0, len);
+            }
+            json = sb.toString();
         }
 
-        String json = sb.toString();
         String fileName = "suneditor.pdf";
         String htmlContent = "";
 

--- a/showcase/src/main/webapp/sections/sunEditor/example-basicUsage.xhtml
+++ b/showcase/src/main/webapp/sections/sunEditor/example-basicUsage.xhtml
@@ -40,12 +40,12 @@
     </h:panelGrid>
 
     <pe:sunEditor id="sunEditor" widgetVar="sunEditor" value="#{basicSunEditorController.html}"
-                  mode="#{basicSunEditorController.mode}" dir="#{basicSunEditorController.rtl ? 'rtl' : 'ltr'}"
-                  theme="#{basicSunEditorController.theme}" locale="#{basicSunEditorController.language}"
-                  toolbar="[['font','fontSize','blockStyle'],['paragraphStyle','blockquote'], ['bold', 'underline', 'italic', 'strike', 'subscript', 'superscript', 'removeFormat'],
-                  '/'
-                  ,['fontColor', 'backgroundColor', 'outdent', 'indent', 'align', 'hr', 'list', 'table'],
-                   ['link', 'image', 'audio', 'video', 'fullScreen', 'showBlocks', 'codeView', 'preview', 'print', 'save']]">
+                   mode="#{basicSunEditorController.mode}" dir="#{basicSunEditorController.rtl ? 'rtl' : 'ltr'}"
+                   theme="#{basicSunEditorController.theme}" locale="#{basicSunEditorController.language}"
+                   toolbar="[['font','fontSize','blockStyle'],['paragraphStyle','blockquote'], ['bold', 'underline', 'italic', 'strike', 'subscript', 'superscript', 'removeFormat'],
+                   '/'
+                   ,['fontColor', 'backgroundColor', 'outdent', 'indent', 'align', 'hr', 'list', 'table'],
+                    ['link', 'image', 'audio', 'video', 'fullScreen', 'showBlocks', 'codeView', 'preview', 'exportPDF', 'save']]">
         <p:ajax event="paste" listener="#{basicSunEditorController.onPaste}"/>
         <p:ajax event="copy" listener="#{basicSunEditorController.onCopy}"/>
         <p:ajax event="cut" listener="#{basicSunEditorController.onCut}"/>

--- a/showcase/src/main/webapp/sections/sunEditor/example-dialog.xhtml
+++ b/showcase/src/main/webapp/sections/sunEditor/example-dialog.xhtml
@@ -22,7 +22,7 @@
                       toolbar="[['font','fontSize','blockStyle'],['paragraphStyle','blockquote'], ['bold', 'underline', 'italic', 'strike', 'subscript', 'superscript', 'removeFormat'],
                   '/'
                   ,['fontColor', 'backgroundColor', 'outdent', 'indent', 'align', 'hr', 'list', 'table'],
-                   ['link', 'image', 'audio', 'video', 'fullScreen', 'showBlocks', 'codeView', 'preview', 'print', 'save']]">
+                   ['link', 'image', 'audio', 'video', 'fullScreen', 'showBlocks', 'codeView', 'preview', 'exportPDF', 'save']]">
             <p:ajax event="save" listener="#{basicSunEditorController.onSave}" update="@this"/>
         </pe:sunEditor>
     </p:dialog>


### PR DESCRIPTION
Resolve: #2514 

http://localhost:8080/showcase/sections/sunEditor/basicUsage.jsf

Updated the button icon (from print to exportPDF):

<img width="827" height="412" alt="image" src="https://github.com/user-attachments/assets/0d627749-c613-424d-973b-6b72f7753326" />


Export:

<img width="973" height="257" alt="image" src="https://github.com/user-attachments/assets/e54a2ad7-dffa-4314-abdf-a36ce10e0966" />

Note: 

The exportPDF plugin always produces a predictable structure: `<style>@page{...}</style>` followed by the actual content `<div>...</div>.`
