### PR TITLE
#2519: SunEditor: Support more themes, showcase update

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/suneditor/SunEditorBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/suneditor/SunEditorBase.java
@@ -71,7 +71,7 @@ public abstract class SunEditorBase extends AbstractEditorInputTextArea {
     @Property(description = "The mode to use: 'classic', 'inline', etc.", defaultValue = "classic")
     public abstract String getMode();
 
-    @Property(description = "The theme to use: 'auto', 'dark', or 'default'.", defaultValue = "auto")
+    @Property(description = "The theme to use: 'auto', 'default', 'dark', 'cobalt', 'cream', or 'midnight'.", defaultValue = "auto")
     public abstract String getTheme();
 
     @Property(description = "Locale for the editor. Can be a string or java.util.Locale instance.")

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/suneditor/BasicSunEditorController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/suneditor/BasicSunEditorController.java
@@ -125,6 +125,9 @@ public class BasicSunEditorController implements Serializable {
         results.add(new SelectItem("auto", "Auto"));
         results.add(new SelectItem("default", "Default"));
         results.add(new SelectItem("dark", "Dark"));
+        results.add(new SelectItem("cobalt", "Cobalt"));
+        results.add(new SelectItem("cream", "Cream"));
+        results.add(new SelectItem("midnight", "Midnight"));
         return results;
     }
 


### PR DESCRIPTION
Resolve: #2519 

http://localhost:8080/showcase/sections/sunEditor/basicUsage.jsf

<img width="821" height="507" alt="image" src="https://github.com/user-attachments/assets/8f0f3b46-7d2d-4129-9cfb-6a7bb2738ef1" />
