### PR TITLE
#2571: Kanban: board text unreadable in dark themes

### DIFF
--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/kanban/1-kanban.css
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/kanban/1-kanban.css
@@ -35,3 +35,27 @@ body .kanban-board header .kanban-title-button:active {
   border-color: #fff;
   color: #fff;
 }
+
+body .kanban-board {
+  background: var(--surface-d, #e2e4e6);
+  color: var(--text-color);
+}
+
+body .kanban-board header {
+  color: var(--text-color);
+}
+
+body .kanban-item {
+  background: var(--surface-card, #fff);
+  color: var(--text-color);
+}
+
+body .drag_handler {
+  background: var(--surface-card, #fff);
+}
+
+body .drag_handler_icon,
+body .drag_handler_icon:before,
+body .drag_handler_icon:after {
+  background: var(--text-color-secondary, #000);
+}


### PR DESCRIPTION
Resolve: #2571 

<img width="922" height="387" alt="image" src="https://github.com/user-attachments/assets/e5549730-d100-49d6-83e7-9dce4000e834" />

<img width="922" height="387" alt="image" src="https://github.com/user-attachments/assets/164e4c37-a940-4c91-9e9b-b3afec0c15b7" />
