### PR TITLE
#2580: Kanban: Add custom data attribute support to KanbanItem

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/kanban/KanbanRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/kanban/KanbanRenderer.java
@@ -23,6 +23,7 @@ package org.primefaces.extensions.component.kanban;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
@@ -156,6 +157,16 @@ public class KanbanRenderer extends CoreRenderer {
                         }
                     }
                     itemJson.put("class", classes);
+                }
+
+                if (item.getData() != null && !item.getData().isEmpty()) {
+                    for (final Map.Entry<String, Object> entry : item.getData().entrySet()) {
+                        final String key = entry.getKey();
+                        final Object value = entry.getValue();
+                        if (value != null && !itemJson.has(key)) {
+                            itemJson.put(key, value);
+                        }
+                    }
                 }
 
                 items.put(itemJson);

--- a/core/src/main/java/org/primefaces/extensions/model/kanban/KanbanItem.java
+++ b/core/src/main/java/org/primefaces/extensions/model/kanban/KanbanItem.java
@@ -22,6 +22,8 @@
 package org.primefaces.extensions.model.kanban;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Model class for a Kanban item.
@@ -37,6 +39,7 @@ public class KanbanItem implements Serializable {
     private String title;
     private String description;
     private String cssClass;
+    private Map<String, Object> data;
 
     public KanbanItem() {
     }
@@ -82,5 +85,34 @@ public class KanbanItem implements Serializable {
 
     public void setCssClass(String cssClass) {
         this.cssClass = cssClass;
+    }
+
+    /**
+     * Returns a map of custom data attributes. Any entry in this map will be rendered as a <code>data-*</code> attribute on the item's DOM element. For
+     * example, an entry <code>"priority", "high"</code> yields <code>data-priority="high"</code> on the card element.
+     *
+     * @return the custom data map, never {@code null}
+     */
+    public Map<String, Object> getData() {
+        if (data == null) {
+            data = new HashMap<>();
+        }
+        return data;
+    }
+
+    public void setData(Map<String, Object> data) {
+        this.data = data;
+    }
+
+    /**
+     * Convenience method to add a single custom data attribute.
+     *
+     * @param key the attribute name (without the <code>data-</code> prefix)
+     * @param value the attribute value
+     * @return this instance for method chaining
+     */
+    public KanbanItem putData(String key, Object value) {
+        getData().put(key, value);
+        return this;
     }
 }

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/kanban/KanbanCustomDataController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/kanban/KanbanCustomDataController.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.kanban;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import org.primefaces.extensions.model.kanban.KanbanColumn;
+import org.primefaces.extensions.model.kanban.KanbanItem;
+
+@Named
+@ViewScoped
+public class KanbanCustomDataController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<KanbanColumn> columns;
+
+    @PostConstruct
+    public void init() {
+        columns = new ArrayList<>();
+
+        KanbanColumn todo = new KanbanColumn();
+        todo.setId("todo");
+        todo.setTitle("To Do");
+        todo.setCssClass("kanban-todo");
+        todo.getItems().addAll(List.of(
+                    new KanbanItem("td-1", "Design new landing page")
+                                .putData("priority", "high")
+                                .putData("assignee", "Alice")
+                                .putData("dueDate", "2026-06-10")
+                                .putData("labels", "design,frontend")
+                                .putData("storyPoints", 5),
+                    new KanbanItem("td-2", "Research competitor features")
+                                .putData("priority", "medium")
+                                .putData("assignee", "Bob")
+                                .putData("dueDate", "2026-06-15")
+                                .putData("labels", "research")
+                                .putData("storyPoints", 3),
+                    new KanbanItem("td-3", "Write unit tests")
+                                .putData("priority", "low")
+                                .putData("assignee", "Carol")
+                                .putData("dueDate", "2026-06-20")
+                                .putData("labels", "testing")
+                                .putData("storyPoints", 8)));
+        columns.add(todo);
+
+        KanbanColumn inprogress = new KanbanColumn();
+        inprogress.setId("inprogress");
+        inprogress.setTitle("In Progress");
+        inprogress.setCssClass("kanban-inprogress");
+        inprogress.getItems().addAll(List.of(
+                    new KanbanItem("ip-1", "Implement OAuth integration")
+                                .putData("priority", "high")
+                                .putData("assignee", "Alice")
+                                .putData("dueDate", "2026-06-05")
+                                .putData("labels", "backend,security")
+                                .putData("storyPoints", 13),
+                    new KanbanItem("ip-2", "API rate limiting")
+                                .putData("priority", "high")
+                                .putData("assignee", "Bob")
+                                .putData("dueDate", "2026-06-08")
+                                .putData("labels", "backend,performance")
+                                .putData("storyPoints", 5)));
+        columns.add(inprogress);
+
+        KanbanColumn done = new KanbanColumn();
+        done.setId("done");
+        done.setTitle("Done");
+        done.setCssClass("kanban-done");
+        done.getItems().addAll(List.of(
+                    new KanbanItem("dn-1", "Setup CI/CD pipeline")
+                                .putData("priority", "high")
+                                .putData("assignee", "Carol")
+                                .putData("dueDate", "2026-05-28")
+                                .putData("labels", "devops")
+                                .putData("storyPoints", 8),
+                    new KanbanItem("dn-2", "Database migration script")
+                                .putData("priority", "medium")
+                                .putData("assignee", "Bob")
+                                .putData("dueDate", "2026-05-30")
+                                .putData("labels", "backend,database")
+                                .putData("storyPoints", 3)));
+        columns.add(done);
+    }
+
+    public List<KanbanColumn> getColumns() {
+        return columns;
+    }
+}

--- a/showcase/src/main/webapp/sections/kanban/customData.xhtml
+++ b/showcase/src/main/webapp/sections/kanban/customData.xhtml
@@ -1,0 +1,50 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="Kanban"/>
+        </f:facet>
+        <p>
+            Any custom key-value data attached to a <code>KanbanItem</code> via
+            <code>putData(key, value)</code> is rendered as a
+            <code>data-*</code> attribute on the card DOM element.
+            This allows you to attach arbitrary metadata such as priority,
+            assignee, due date, or story points to each card.
+        </p>
+        <p>
+            The data attributes are rendered on each card as visual badges
+            (priority, assignee, due date, labels, story points) via the
+            <code>extender</code> callback, and are also available for CSS
+            attribute selectors (e.g. <code>[data-priority="high"]</code>)
+            and JavaScript via <code>element.dataset.*</code>.
+            Inspect a card with your browser's developer tools to see the
+            <code>data-*</code> attributes on the DOM element.
+        </p>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/kanban/example-customData.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+${showcase:getFileContent('/sections/kanban/example-customData.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/kanban/KanbanCustomDataController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/kanban/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="kanban"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/kanban/example-customData.xhtml
+++ b/showcase/src/main/webapp/sections/kanban/example-customData.xhtml
@@ -1,0 +1,69 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces"
+    xmlns:pe="primefaces.extensions" xmlns:f="jakarta.faces.core">
+
+    <style>
+        .kanban-board header.kanban-todo { background: #6366f1; color: #fff; }
+        .kanban-board header.kanban-inprogress { background: #f59e0b; color: #fff; }
+        .kanban-board header.kanban-done { background: #10b981; color: #fff; }
+
+        .kanban-item-title { font-weight: 600; }
+        .kanban-item-description { font-size: 0.8rem; opacity: 0.7; margin-top: 2px; }
+
+        .kanban-item[data-priority="high"] { border-left: 4px solid #ef4444; }
+        .kanban-item[data-priority="medium"] { border-left: 4px solid #f59e0b; }
+        .kanban-item[data-priority="low"] { border-left: 4px solid #10b981; }
+
+        .kanban-badges { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+        .kanban-badge { font-size: 0.65rem; padding: 1px 6px; border-radius: 3px; font-weight: 600; }
+        .kb-priority-high { background: #fef2f2; color: #dc2626; }
+        .kb-priority-medium { background: #fffbeb; color: #d97706; }
+        .kb-priority-low { background: #f0fdf4; color: #16a34a; }
+        .kb-assignee { background: #eef2ff; color: #4f46e5; }
+        .kb-duedate { background: #fef3c7; color: #92400e; }
+        .kb-points { background: #d1fae5; color: #065f46; }
+        .kb-label { background: #f3e8ff; color: #7c3aed; }
+    </style>
+
+<!-- EXAMPLE-SOURCE-START -->
+    <h:outputScript>
+        //<![CDATA[
+        function kanbanExtender() {
+            this.boards.forEach(function(board) {
+                (board.item || []).forEach(function(item) {
+                    var badges = [];
+
+                    if (item.priority) badges.push(
+                        '<span class="kanban-badge kb-priority-' + item.priority + '">' + item.priority + '</span>');
+
+                    if (item.assignee) badges.push(
+                        '<span class="kanban-badge kb-assignee">' + item.assignee + '</span>');
+
+                    if (item.dueDate) badges.push(
+                        '<span class="kanban-badge kb-duedate">' + item.dueDate + '</span>');
+
+                    if (item.storyPoints) badges.push(
+                        '<span class="kanban-badge kb-points">' + item.storyPoints + 'pts</span>');
+
+                    if (item.labels) {
+                        item.labels.split(',').forEach(function(l) {
+                            badges.push('<span class="kanban-badge kb-label">' + l.trim() + '</span>');
+                        });
+                    }
+
+                    if (badges.length) {
+                        item.title += '<div class="kanban-badges">' + badges.join('') + '</div>';
+                    }
+                });
+            });
+        }
+        //]]>
+    </h:outputScript>
+
+    <pe:kanban id="kanbanCustomData"
+                value="#{kanbanCustomDataController.columns}"
+                draggable="true"
+                extender="kanbanExtender"
+                style="height:400px" />
+<!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/kanban/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/kanban/useCasesChoice.xhtml
@@ -31,6 +31,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('clientApi')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/kanban/clientApi.jsf"/>
+        <p:menuitem value="Custom Data Attributes"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('customData')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/kanban/customData.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
Resolve: #2580 

Sample: 

http://localhost:8080/showcase/sections/kanban/customData.jsf

<img width="274" height="412" alt="image" src="https://github.com/user-attachments/assets/892bc3bb-947a-45ca-82fa-ed0376a3596d" />
