### PR TITLE
#2583: Kanban: Add drag handle support to Kanban component

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/kanban/KanbanBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/kanban/KanbanBase.java
@@ -104,4 +104,8 @@ public abstract class KanbanBase extends UIComponentBase implements Widget {
 
     @Property(description = "Client-side id of a PrimeFaces contextMenu component to bind to right-click events.")
     public abstract String getBindContextMenu();
+
+    @Property(description = "Enable drag handle on items. When enabled, only the handle area is draggable, preventing accidental drags on the card body.",
+                defaultValue = "false")
+    public abstract boolean isDragHandle();
 }

--- a/core/src/main/java/org/primefaces/extensions/component/kanban/KanbanRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/kanban/KanbanRenderer.java
@@ -108,6 +108,7 @@ public class KanbanRenderer extends CoreRenderer {
         wb.nativeAttr("extender", kanban.getExtender());
         wb.nativeAttr("boards", data);
         wb.attr("bindContextMenu", kanban.getBindContextMenu());
+        wb.attr("dragHandle", kanban.isDragHandle());
 
         encodeClientBehaviors(context, kanban);
         wb.finish();

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/kanban/1-kanban.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/kanban/1-kanban.js
@@ -33,6 +33,7 @@ if (PrimeFaces.widget) {
                     content: '+ Add Item',
                     footer: false
                 },
+                itemHandleOptions: this._buildHandleOptions(),
                 dropEl: function(el, target, source, sibling) {
                     if (!target.contains(el)) {
                         return;
@@ -241,6 +242,20 @@ if (PrimeFaces.widget) {
                     container.innerHTML = '';
                 }
             }
+        }
+
+        _buildHandleOptions() {
+            var opts = {
+                enabled: this.cfg.dragHandle === true
+            };
+            if (this.cfg.itemHandleOptions) {
+                for (var k in this.cfg.itemHandleOptions) {
+                    if (this.cfg.itemHandleOptions.hasOwnProperty(k)) {
+                        opts[k] = this.cfg.itemHandleOptions[k];
+                    }
+                }
+            }
+            return opts;
         }
     };
 }

--- a/showcase/src/main/java/org/primefaces/extensions/showcase/controller/kanban/KanbanDragHandleController.java
+++ b/showcase/src/main/java/org/primefaces/extensions/showcase/controller/kanban/KanbanDragHandleController.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2011-2026 PrimeFaces Extensions
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.primefaces.extensions.showcase.controller.kanban;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import org.primefaces.extensions.event.KanbanDragEvent;
+import org.primefaces.extensions.model.kanban.KanbanColumn;
+import org.primefaces.extensions.model.kanban.KanbanItem;
+
+@Named
+@ViewScoped
+public class KanbanDragHandleController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<KanbanColumn> columns;
+
+    private boolean dragHandle = true;
+    private String handleStyle = "default";
+
+    @PostConstruct
+    public void init() {
+        columns = new ArrayList<>();
+
+        KanbanColumn todoColumn = new KanbanColumn("todo", "To Do");
+        todoColumn.setCssClass("kanban-todo");
+        todoColumn.addItem(new KanbanItem("item1", "Add support for Kanban",
+                    "Create a new Kanban component for PrimeFaces Extensions"));
+        todoColumn.addItem(new KanbanItem("item2", "Write documentation",
+                    "Document the new component"));
+
+        KanbanColumn inProgressColumn = new KanbanColumn("inprogress", "In Progress");
+        inProgressColumn.setCssClass("kanban-inprogress");
+        inProgressColumn.addItem(new KanbanItem("item3", "Design component",
+                    "Design the Kanban board component"));
+
+        KanbanColumn doneColumn = new KanbanColumn("done", "Done");
+        doneColumn.setCssClass("kanban-done");
+        doneColumn.addItem(new KanbanItem("item4", "Research libraries",
+                    "Research available Kanban libraries"));
+
+        columns.add(todoColumn);
+        columns.add(inProgressColumn);
+        columns.add(doneColumn);
+    }
+
+    public void onDrop(KanbanDragEvent event) {
+        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, "Item Moved",
+                    "Item " + event.getItemId() + " moved from " + event.getSourceColumnId()
+                                + " to " + event.getTargetColumnId() + " at position " + event.getNewPosition());
+        FacesContext.getCurrentInstance().addMessage(null, message);
+    }
+
+    public List<KanbanColumn> getColumns() {
+        return columns;
+    }
+
+    public boolean isDragHandle() {
+        return dragHandle;
+    }
+
+    public void setDragHandle(boolean dragHandle) {
+        this.dragHandle = dragHandle;
+    }
+
+    public String getHandleStyle() {
+        return handleStyle;
+    }
+
+    public void setHandleStyle(String handleStyle) {
+        this.handleStyle = handleStyle;
+    }
+
+    public String getExtender() {
+        if (!dragHandle) {
+            return null;
+        }
+        if ("grip".equals(handleStyle)) {
+            return "kanbanDragHandleGrip";
+        }
+        return "kanbanDragHandleDefault";
+    }
+}

--- a/showcase/src/main/webapp/sections/kanban/dragHandle.xhtml
+++ b/showcase/src/main/webapp/sections/kanban/dragHandle.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:showcase="primefaces.extensions.showcase">
+<ui:composition template="/templates/showcaseLayout.xhtml">
+    <ui:define name="centerContent">
+        <f:facet name="header">
+            <h:outputText value="Kanban"/>
+        </f:facet>
+        <h:panelGroup layout="block" styleClass="centerContent">
+            Drag handles provide a dedicated area for grabbing and moving cards. When enabled, only the handle icon on each item is draggable, preventing accidental drags when clicking on card content. This is especially useful when items contain interactive elements or when precise click vs. drag distinction is needed.
+        </h:panelGroup>
+
+        <h:panelGroup layout="block" styleClass="centerExample">
+            <ui:include src="/sections/kanban/example-dragHandle.xhtml"/>
+        </h:panelGroup>
+
+        <ui:decorate template="/templates/twoTabsDecorator.xhtml">
+            <ui:define name="contentTab1">
+${showcase:getFileContent('/sections/kanban/example-dragHandle.xhtml')}
+            </ui:define>
+            <ui:define name="contentTab2">
+${showcase:getFileContent('/org/primefaces/extensions/showcase/controller/kanban/KanbanDragHandleController.java')}
+            </ui:define>
+        </ui:decorate>
+    </ui:define>
+    <ui:define name="useCases">
+        <ui:include src="/sections/kanban/useCasesChoice.xhtml"/>
+    </ui:define>
+    <ui:define name="docuTable">
+        <ui:include src="/sections/shared/documentation.xhtml">
+            <ui:param name="tagName" value="kanban"/>
+        </ui:include>
+    </ui:define>
+</ui:composition>
+</html>

--- a/showcase/src/main/webapp/sections/kanban/example-dragHandle.xhtml
+++ b/showcase/src/main/webapp/sections/kanban/example-dragHandle.xhtml
@@ -1,0 +1,78 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html"
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces"
+    xmlns:pe="primefaces.extensions" xmlns:f="jakarta.faces.core">
+
+    <style>
+        .kanban-board header.kanban-todo { background-color: #4f46e5; color: #fff; }
+        .kanban-board header.kanban-inprogress { background-color: #ea580c; color: #fff; }
+        .kanban-board header.kanban-done { background-color: #16a34a; color: #fff; }
+        .kanban-item-title { font-weight: 600; }
+        .kanban-item-description { font-size: 0.8rem; opacity: 0.7; margin-top: 2px; }
+
+        .drag_handler { margin-right: 8px; float: left; }
+
+        .drag_handler_grip {
+            float: left;
+            width: 16px;
+            height: 24px;
+            margin-right: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: grab;
+            opacity: .3;
+            transition: opacity .15s;
+        }
+        .drag_handler_grip:hover { opacity: .7; }
+        .drag_handler_grip_icon {
+            width: 3px;
+            height: 3px;
+            border-radius: 50%;
+            background: var(--text-color-secondary);
+            box-shadow: 0 -6px 0 var(--text-color-secondary), 0 6px 0 var(--text-color-secondary);
+        }
+    </style>
+
+    <p:growl id="growl" showDetail="true" showSummary="true">
+        <p:autoUpdate />
+    </p:growl>
+
+<!-- EXAMPLE-SOURCE-START -->
+    <h:outputScript>
+        function kanbanDragHandleDefault() {}
+
+        function kanbanDragHandleGrip() {
+            this.cfg.itemHandleOptions = {
+                customCssHandler: 'drag_handler_grip',
+                customCssIconHandler: 'drag_handler_grip_icon'
+            };
+        }
+    </h:outputScript>
+
+    <div style="margin-bottom:8px">
+        <p:outputLabel for="dragHandle" value="Drag Handle" styleClass="font-bold" style="margin-right:8px" />
+        <p:selectOneMenu id="dragHandle" value="#{kanbanDragHandleController.dragHandle}" style="width:120px">
+            <f:selectItem itemLabel="Enabled" itemValue="true" />
+            <f:selectItem itemLabel="Disabled" itemValue="false" />
+            <p:ajax update="kanban" process="@this" />
+        </p:selectOneMenu>
+
+        <p:outputLabel for="handleStyle" value="Handle Style" styleClass="font-bold" style="margin:0 8px 0 16px" />
+        <p:selectOneMenu id="handleStyle" value="#{kanbanDragHandleController.handleStyle}" style="width:140px">
+            <f:selectItem itemLabel="Default" itemValue="default" />
+            <f:selectItem itemLabel="Grip" itemValue="grip" />
+            <p:ajax update="kanban" process="@this" />
+        </p:selectOneMenu>
+    </div>
+
+    <pe:kanban id="kanban"
+                widgetVar="kanbanDragHandleWidget"
+                value="#{kanbanDragHandleController.columns}"
+                draggable="true"
+                dragHandle="#{kanbanDragHandleController.dragHandle}"
+                extender="#{kanbanDragHandleController.extender}"
+                style="height:400px">
+        <p:ajax event="drop" listener="#{kanbanDragHandleController.onDrop}" update="growl" />
+    </pe:kanban>
+<!-- EXAMPLE-SOURCE-END -->
+</ui:composition>

--- a/showcase/src/main/webapp/sections/kanban/useCasesChoice.xhtml
+++ b/showcase/src/main/webapp/sections/kanban/useCasesChoice.xhtml
@@ -35,6 +35,10 @@
                     styleClass="#{navigationContext.getMenuitemStyleClass('customData')}"
                     onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
                     url="#{request.contextPath}/sections/kanban/customData.jsf"/>
+        <p:menuitem value="Drag Handles"
+                    styleClass="#{navigationContext.getMenuitemStyleClass('dragHandle')}"
+                    onclick="Showcase.selectUseCaseLink(this)" ajax="false" icon="pi pi-play"
+                    url="#{request.contextPath}/sections/kanban/dragHandle.jsf"/>
     </p:menu>
 </ui:composition>
 </html>


### PR DESCRIPTION
Resolve: #2583 

Demo: 

http://localhost:8080/showcase/sections/kanban/dragHandle.jsf


- Without handler: 

<img width="571" height="358" alt="image" src="https://github.com/user-attachments/assets/8017af86-9acc-49a8-8971-ed189446c22d" />


- Default handler:

<img width="571" height="358" alt="image" src="https://github.com/user-attachments/assets/c468f3b9-7395-4874-87da-cd8bfe74f9ec" />

- Customized handler:

<img width="571" height="358" alt="image" src="https://github.com/user-attachments/assets/2d4aea99-2cbc-4a93-92b0-9b0225ffd511" />
