### PR TITLE
#2608: Showcase enhancement: Make showcase responsive and mobile-friendly

### DIFF
--- a/showcase/src/main/webapp/resources/css/layout.css
+++ b/showcase/src/main/webapp/resources/css/layout.css
@@ -269,3 +269,169 @@ body .ui-menu .ui-menu-list .ui-menuitem .ui-menuitem-link .ui-menuitem-icon.ui-
     background-size: 200px 55px;
     left: -20px;
 }
+
+@media (max-width: 991px) {
+    html, body {
+        overflow-x: hidden !important;
+        overflow-y: auto !important;
+        height: auto !important;
+    }
+    
+    #fpl {
+        position: static !important;
+        height: auto !important;
+        width: 100% !important;
+        overflow: visible !important;
+    }
+    
+    .ui-layout-pane,
+    .ui-layout-content,
+    [id^="layout"] {
+        position: static !important;
+        width: 100% !important;
+        height: auto !important;
+        top: auto !important;
+        bottom: auto !important;
+        left: auto !important;
+        right: auto !important;
+        display: block !important;
+        box-sizing: border-box !important;
+    }
+    
+    #layoutNorth,
+    .ui-layout-north,
+    .ui-layout-pane-north {
+        position: static !important;
+        width: 100% !important;
+        height: auto !important;
+        padding: 5px !important;
+        display: block !important;
+    }
+    
+    #layoutSouth,
+    .ui-layout-south,
+    .ui-layout-pane-south {
+        position: static !important;
+        width: 100% !important;
+        height: auto !important;
+        margin-top: 15px !important;
+        text-align: center !important;
+        display: block !important;
+    }
+    
+    #layoutCenter,
+    .ui-layout-center,
+    .ui-layout-pane-center {
+        position: static !important;
+        width: 100% !important;
+        height: auto !important;
+        padding: 10px !important;
+        overflow: visible !important;
+        display: block !important;
+    }
+    
+    #layoutWest,
+    .ui-layout-west,
+    .ui-layout-pane-west {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        bottom: 0 !important;
+        left: -290px !important;
+        width: 280px !important;
+        height: 100% !important;
+        z-index: 10001 !important;
+        overflow-y: auto !important;
+        transition: left 0.3s ease !important;
+        box-shadow: 2px 0 10px rgba(0, 0, 0, 0.25) !important;
+        background-color: var(--card-background-color, #ffffff) !important;
+        border-right: 1px solid var(--divider-color, #dddddd) !important;
+    }
+    #layoutWest.mobile-open,
+    .ui-layout-west.mobile-open,
+    .ui-layout-pane-west.mobile-open {
+        left: 0 !important;
+    }
+    
+    #layoutEast,
+    .ui-layout-east,
+    .ui-layout-pane-east {
+        display: block !important;
+        position: fixed !important;
+        top: 0 !important;
+        bottom: 0 !important;
+        right: -330px !important;
+        width: 320px !important;
+        height: 100% !important;
+        z-index: 10001 !important;
+        overflow-y: auto !important;
+        transition: right 0.3s ease !important;
+        box-shadow: -2px 0 10px rgba(0, 0, 0, 0.25) !important;
+        background-color: var(--card-background-color, #ffffff) !important;
+        border-left: 1px solid var(--divider-color, #dddddd) !important;
+    }
+    #layoutEast.mobile-open,
+    .ui-layout-east.mobile-open,
+    .ui-layout-pane-east.mobile-open {
+        right: 0 !important;
+    }
+    
+    #layoutWest .ui-layout-pane,
+    #layoutEast .ui-layout-pane,
+    .ui-layout-pane-west .ui-layout-pane,
+    .ui-layout-pane-east .ui-layout-pane {
+        position: static !important;
+        width: 100% !important;
+        height: auto !important;
+        top: auto !important;
+        bottom: auto !important;
+        left: auto !important;
+        right: auto !important;
+        display: block !important;
+        overflow: visible !important;
+        border: none !important;
+        box-shadow: none !important;
+    }
+    
+    .ui-layout-resizer {
+        display: none !important;
+    }
+    
+    .mobile-menu-btn {
+        display: inline-block !important;
+    }
+    
+    .ui-panelgrid.ui-widget {
+        display: flex !important;
+        justify-content: space-between !important;
+        align-items: center !important;
+        flex-wrap: nowrap !important;
+        padding: 5px !important;
+    }
+    
+    .ui-panelgrid-cell {
+        width: auto !important;
+        padding: 0 !important;
+    }
+    
+    .ui-datatable {
+        width: 100% !important;
+        overflow-x: auto !important;
+        -webkit-overflow-scrolling: touch !important;
+    }
+    
+    div.centerContent,
+    div.centerExample {
+        padding: 10px 5px !important;
+    }
+}
+
+@media (max-width: 768px) {
+    #logo-text {
+        display: none !important;
+    }
+    
+    .themeText {
+        display: none !important;
+    }
+}

--- a/showcase/src/main/webapp/resources/js/showcase.js
+++ b/showcase/src/main/webapp/resources/js/showcase.js
@@ -36,6 +36,21 @@ var Showcase = (function () {
                 // show the HTML pane after everything has been asjusted
                 // https://stackoverflow.com/questions/9550760/hide-page-until-everything-is-loaded-advanced/9551066
                 document.getElementsByTagName("html")[0].style.visibility = "visible";
+
+                $(document).on("click", function (event) {
+                    if (window.innerWidth < 991) {
+                        var westPane = $("#layoutWest, .ui-layout-pane-west");
+                        var eastPane = $("#layoutEast, .ui-layout-pane-east");
+                        
+                        if (westPane.hasClass("mobile-open") && !westPane.is(event.target) && westPane.has(event.target).length === 0 && !$(event.target).closest(".mobile-menu-btn-west").length) {
+                            westPane.removeClass("mobile-open");
+                        }
+                        
+                        if (eastPane.hasClass("mobile-open") && !eastPane.is(event.target) && eastPane.has(event.target).length === 0 && !$(event.target).closest(".mobile-menu-btn-east").length) {
+                            eastPane.removeClass("mobile-open");
+                        }
+                    }
+                });
             });
         },
 

--- a/showcase/src/main/webapp/sections/system/header.xhtml
+++ b/showcase/src/main/webapp/sections/system/header.xhtml
@@ -6,13 +6,16 @@
 <ui:composition>
     <p:panel>
         <p:panelGrid columns="2" layout="flex">
-            <h:panelGrid columns="2" style="float:left;">
+            <h:panelGrid columns="3" style="float:left; display: flex; align-items: center;">
+                <p:commandButton icon="pi pi-bars" onclick="$('#layoutWest, .ui-layout-pane-west').toggleClass('mobile-open'); return false;"
+                                 styleClass="ui-button-flat mobile-menu-btn mobile-menu-btn-west"
+                                 style="display: none; margin-right: 10px;" title="Toggle Menu"/>
                 <p:link id="logo-link" href="#{request.contextPath}/views/home.jsf" title="PrimeFaces Extensions" styleClass="logo"/>
                 <p:link id="logo-text" href="#{request.contextPath}/views/home.jsf" title="PrimeFaces Extensions" styleClass="logo"/>
             </h:panelGrid>
 
 
-            <h:panelGrid columns="5" style="float:right;">
+            <h:panelGrid columns="6" style="float:right; display: flex; align-items: center;">
                 <p:ajaxStatus style="z-index:9999;">
                     <f:facet name="start">
                         <i class="pi pi-spin pi-spinner ajax-loader" aria-hidden="true"></i>
@@ -22,7 +25,7 @@
                     </f:facet>
                 </p:ajaxStatus>
 
-                <h:panelGrid columns="2" columnClasses="themeText,themeSelect">
+                <h:panelGrid columns="2" columnClasses="themeText,themeSelect" style="display: flex; align-items: center;">
                     <p:outputLabel for="themeSelectMenu" value="Theme"/>
                     <p:selectOneMenu id="themeSelectMenu" value="#{userSettings.currentTheme}" var="theme" effect="drop"
                                      converter="themeConverter">
@@ -41,6 +44,9 @@
                 <p:button href="https://github.com/primefaces-extensions/primefaces-extensions/issues" target="_blank" title="Issue Tracking"
                           icon="pi pi-exclamation-triangle" styleClass="ui-button-flat"/>
 
+                <p:commandButton icon="pi pi-list" onclick="$('#layoutEast, .ui-layout-pane-east').toggleClass('mobile-open'); return false;"
+                                 styleClass="ui-button-flat mobile-menu-btn mobile-menu-btn-east"
+                                 style="display: none; margin-left: 10px;" title="Toggle Use Cases"/>
             </h:panelGrid>
         </p:panelGrid>
     </p:panel>


### PR DESCRIPTION
Resolve: #2608 

Desktop View behavior stays the same

---

Mobile View: 

<img width="366" height="508" alt="image" src="https://github.com/user-attachments/assets/6b1de122-e0f4-4556-8b21-088a0fd92be8" />


Mobile left layout pane:

<img width="357" height="507" alt="image" src="https://github.com/user-attachments/assets/b79a3c5d-49a7-42ab-b9f7-5941c7ece7e7" />

Mobile right layout pane:

<img width="366" height="495" alt="image" src="https://github.com/user-attachments/assets/8a15c197-9bc7-4ffe-bf2f-820b77081776" />

Mobile dark theme:

<img width="357" height="562" alt="image" src="https://github.com/user-attachments/assets/b138aa1b-2773-4bc3-8995-edcc29d9cebc" />

