### PR TITLE
#2632: TriStateManyCheckbox CDK migration follow-up - null-guards the.isEmpty() calls that caused the NPE

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/tristatemanycheckbox/TriStateManyCheckboxRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/tristatemanycheckbox/TriStateManyCheckboxRenderer.java
@@ -259,8 +259,9 @@ public class TriStateManyCheckboxRenderer extends SelectManyRenderer<TriStateMan
         String dataTitles = Constants.EMPTY_STRING;
         String titleAtt = Constants.EMPTY_STRING;
 
-        if (!checkbox.getStateOneTitle().isEmpty()
-                    || !checkbox.getStateTwoTitle().isEmpty() || !checkbox.getStateThreeTitle().isEmpty()) {
+        if ((checkbox.getStateOneTitle() != null && !checkbox.getStateOneTitle().isEmpty())
+                    || (checkbox.getStateTwoTitle() != null && !checkbox.getStateTwoTitle().isEmpty())
+                    || (checkbox.getStateThreeTitle() != null && !checkbox.getStateThreeTitle().isEmpty())) {
             // preparation with singe quotes for .data('titlestates')
             dataTitles = "data-titlestates='" + statesTitles + "' ";
             // active title Att


### PR DESCRIPTION
Resolve: #2632 