### PR TITLE
#2718: new option: outsideClickDeselectsBoolean

### DIFF
--- a/core/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
+++ b/core/src/main/java/org/primefaces/extensions/component/sheet/Sheet.java
@@ -856,7 +856,10 @@ public class Sheet extends SheetBaseImpl {
         }
 
         if (restoredSortedList == null) {
-            getFilteredValue().clear();
+            final List<Object> filteredValue = getFilteredValue();
+            if (filteredValue != null) {
+                filteredValue.clear();
+            }
         }
         else {
             setFilteredValue((List<Object>) restoredSortedList);

--- a/core/src/main/java/org/primefaces/extensions/component/sheet/SheetBase.java
+++ b/core/src/main/java/org/primefaces/extensions/component/sheet/SheetBase.java
@@ -202,6 +202,10 @@ public abstract class SheetBase extends UIInput implements ClientBehaviorHolder,
     @Property(description = "Allow tab off sheet.", defaultValue = "false")
     public abstract boolean isAllowTabOffSheet();
 
+    @Property(description = "Whether a click outside the sheet deselects the current selection. When false, the selection is only cleared when selecting another cell.",
+                defaultValue = "true")
+    public abstract boolean isOutsideClickDeselects();
+
     @Property(description = "Tab index.", defaultValue = "0")
     public abstract String getTabindex();
 

--- a/core/src/main/java/org/primefaces/extensions/component/sheet/SheetRenderer.java
+++ b/core/src/main/java/org/primefaces/extensions/component/sheet/SheetRenderer.java
@@ -228,6 +228,7 @@ public class SheetRenderer extends CoreRenderer<Sheet> {
         encodeOptionalNativeAttr(wb, "manualColumnMove", sheet.isMovableCols());
         encodeOptionalNativeAttr(wb, "manualRowMove", sheet.isMovableRows());
         encodeOptionalNativeAttr(wb, "allowTabOffSheet", sheet.isAllowTabOffSheet());
+        encodeOptionalNativeAttr(wb, "outsideClickDeselects", sheet.isOutsideClickDeselects());
         encodeOptionalNativeAttr(wb, "width", sheet.getWidth());
         encodeOptionalNativeAttr(wb, "height", sheet.getHeight());
         encodeOptionalNativeAttr(wb, "minRows", sheet.getMinRows());

--- a/core/src/main/resources/META-INF/resources/primefaces-extensions/sheet/1-sheet.js
+++ b/core/src/main/resources/META-INF/resources/primefaces-extensions/sheet/1-sheet.js
@@ -53,6 +53,7 @@ PrimeFaces.widget.ExtSheet = class extends PrimeFaces.widget.DeferredWidget {
             columns: $this.cfg.columns,
             stretchH: $this.cfg.stretchH || 'all',
             selectionMode: $this.cfg.selectionMode || 'multiple',
+            outsideClickDeselects: $this.cfg.outsideClickDeselects,
             contextMenu: false,
             allowInvalid: false,
             autoRowSize: !$this.cfg.rowHeaders,


### PR DESCRIPTION
Resolve: #2718 


https://josepsanzcamp.github.io/handsontable-6.2.2-docs/Options.html#outsideClickDeselects


> If true, mouse click outside the grid will deselect the current selection. Can be a function that takes the
click event target and returns a boolean.

> Default Value: true
Example
// don't clear current selection when mouse click was outside the grid
outsideClickDeselects: false,

> // or
outsideClickDeselects: function(event) {
  return false;
}